### PR TITLE
📦 Publish @morinoparty/chlorophyll-react via GitHub Packages

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -45,6 +45,16 @@
         "description": "Type: Security update"
     },
     {
+        "name": "breaking",
+        "color": "#B60205",
+        "description": "Type: Breaking change (bumps major version)"
+    },
+    {
+        "name": "skip-changelog",
+        "color": "#CCCCCC",
+        "description": "Scope: Exclude from release notes"
+    },
+    {
         "name": "component",
         "color": "#7057FF",
         "description": "Scope: UI Components"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,58 @@
+name-template: "@morinoparty/chlorophyll-react v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+version-template: "$MAJOR.$MINOR.$PATCH"
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+      - "requirement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "♻️ Refactor"
+    labels:
+      - "refactor"
+  - title: "🧪 Tests"
+    labels:
+      - "test"
+  - title: "📚 Documentation"
+    labels:
+      - "document"
+  - title: "🔒 Dependencies"
+    labels:
+      - "dependencies"
+
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+# ラベルでバージョンを自動決定する
+version-resolver:
+  major:
+    labels:
+      - "breaking"
+      - "major"
+  minor:
+    labels:
+      - "enhancement"
+      - "requirement"
+      - "minor"
+  patch:
+    labels:
+      - "bug"
+      - "refactor"
+      - "test"
+      - "document"
+      - "dependencies"
+      - "patch"
+  default: patch
+
+exclude-labels:
+  - "duplicate"
+  - "wontfix"
+  - "skip-changelog"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/_a11y.yml
+++ b/.github/workflows/_a11y.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/.github/workflows/_preview-deploy.yml
+++ b/.github/workflows/_preview-deploy.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build storybook
         run: pnpm --filter @chlorophyll/storybook build

--- a/.github/workflows/_vrt.yml
+++ b/.github/workflows/_vrt.yml
@@ -52,7 +52,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -108,7 +108,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         name: Install pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -1,0 +1,73 @@
+name: Publish React Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.0.2). Leave empty to use the version in package.json"
+        required: false
+        type: string
+  # GitHub Release が publish されたタイミング (release-drafter 経由を想定)
+  release:
+    types: [published]
+  # 手動で v* タグを push した場合のフォールバック
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+        with:
+          run_install: false
+
+      # Node.js は GitHub Packages レジストリに向ける (@morinoparty スコープ用)
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@morinoparty"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 手動トリガーで version を指定された場合は package.json を書き換える
+      - name: Override version (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}
+        working-directory: packages/react
+        run: |
+          npm version "${{ inputs.version }}" --no-git-tag-version --allow-same-version
+
+      # タグ push からバージョンを抽出 (例: v0.0.2 → 0.0.2)
+      - name: Sync version from tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        working-directory: packages/react
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+
+      # release イベント経由 (release-drafter) の場合はリリース tag_name から抽出
+      - name: Sync version from release
+        if: ${{ github.event_name == 'release' }}
+        working-directory: packages/react
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#v}"
+          npm version "$TAG_VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish to GitHub Packages
+        working-directory: packages/react
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm publish --no-git-checks --access public

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -14,7 +12,7 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6

--- a/docs/app/routes/index.tsx
+++ b/docs/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@chlorophyll/react";
+import { Button } from "@morinoparty/chlorophyll-react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { sva } from "styled-system/css";
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     },
     "dependencies": {
         "@ark-ui/react": "^5.30.0",
-        "@chlorophyll/react": "workspace:*",
+        "@morinoparty/chlorophyll-react": "workspace:*",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-presence": "^1.1.5",

--- a/docs/panda.config.ts
+++ b/docs/panda.config.ts
@@ -1,4 +1,4 @@
-import { createPreset, stone } from "@chlorophyll/react/preset";
+import { createPreset, stone } from "@morinoparty/chlorophyll-react/preset";
 import { defineConfig } from "@pandacss/dev";
 
 export default defineConfig({

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
         "culori": "^4.0.2"
     },
     "devDependencies": {
-        "@chlorophyll/react": "workspace:*",
+        "@morinoparty/chlorophyll-react": "workspace:*",
         "typescript": "~5.9.3",
         "unbuild": "^3.5.0"
     },

--- a/packages/cli/src/loaders/token-loader.ts
+++ b/packages/cli/src/loaders/token-loader.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { ColorPaletteSpec, SemanticTokensSpec, SpecData, TokensSpec } from "../types/index.js";
 
 /**
- * Load spec files from @chlorophyll/react styled-system/specs
+ * Load spec files from @morinoparty/chlorophyll-react styled-system/specs
  */
 export async function loadSpecs(): Promise<SpecData> {
     const specsDir = await resolveSpecsPath();

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@chlorophyll/react",
+    "name": "@morinoparty/chlorophyll-react",
     "version": "0.0.1",
     "type": "module",
     "main": "./src/index.ts",
@@ -16,7 +16,22 @@
         "./components": {
             "types": "./src/components/index.ts",
             "import": "./src/components/index.ts"
-        }
+        },
+        "./style.css": "./style.css"
+    },
+    "files": [
+        "src",
+        "style.css",
+        "README.md"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/morinoparty/chlorophyll.git",
+        "directory": "packages/react"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://npm.pkg.github.com"
     },
     "scripts": {
         "prepare": "panda codegen",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@ark-ui/react':
         specifier: ^5.30.0
         version: 5.30.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@chlorophyll/react':
+      '@morinoparty/chlorophyll-react':
         specifier: workspace:*
         version: link:../packages/react
       '@radix-ui/react-collapsible':
@@ -133,7 +133,7 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2
     devDependencies:
-      '@chlorophyll/react':
+      '@morinoparty/chlorophyll-react':
         specifier: workspace:*
         version: link:../react
       typescript:
@@ -173,7 +173,7 @@ importers:
 
   storybook:
     dependencies:
-      '@chlorophyll/react':
+      '@morinoparty/chlorophyll-react':
         specifier: workspace:*
         version: link:../packages/react
       lucide-react:

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -13,7 +13,7 @@
         "test:runner": "pnpm dlx concurrently -k -s first \"pnpm serve:storybook\" \"pnpm dlx wait-on tcp:6006 && pnpm test\""
     },
     "dependencies": {
-        "@chlorophyll/react": "workspace:*",
+        "@morinoparty/chlorophyll-react": "workspace:*",
         "lucide-react": "^0.562.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.3",

--- a/storybook/panda.config.ts
+++ b/storybook/panda.config.ts
@@ -1,4 +1,4 @@
-import { createPreset, stone } from "@chlorophyll/react/preset";
+import { createPreset, stone } from "@morinoparty/chlorophyll-react/preset";
 import { defineConfig } from "@pandacss/dev";
 
 export default defineConfig({

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -4,8 +4,8 @@
         "baseUrl": ".",
         "paths": {
             "styled-system/*": ["./styled-system/*"],
-            "@chlorophyll/react": ["../packages/ui/src"],
-            "@chlorophyll/react/*": ["../packages/ui/src/*"]
+            "@morinoparty/chlorophyll-react": ["../packages/ui/src"],
+            "@morinoparty/chlorophyll-react/*": ["../packages/ui/src/*"]
         }
     },
     "include": [

--- a/storybook/vite.config.ts
+++ b/storybook/vite.config.ts
@@ -10,11 +10,11 @@ export default defineConfig({
                 replacement: `${__dirname}/styled-system/`,
             },
             {
-                find: "@chlorophyll/react/style.css",
+                find: "@morinoparty/chlorophyll-react/style.css",
                 replacement: `${__dirname}/../packages/ui/style.css`,
             },
             {
-                find: "@chlorophyll/react",
+                find: "@morinoparty/chlorophyll-react",
                 replacement: `${__dirname}/../packages/ui/src`,
             },
         ],


### PR DESCRIPTION
## Summary

- Rename `@chlorophyll/react` → `@morinoparty/chlorophyll-react` so the scope matches the GitHub org required by GitHub Packages
- Add a `publish-react` workflow that publishes to GitHub Packages on `workflow_dispatch`, `release: published`, or `v*` tag push
- Add `release-drafter` config + workflow to auto-draft releases and resolve versions from PR labels (`breaking`/`enhancement`/`bug` → major/minor/patch)
- Add `breaking` / `skip-changelog` labels to `.github/labels.json`
- Use `--frozen-lockfile` in all CI workflows

## Release flow

1. PRs get labeled (`bug`, `enhancement`, `breaking`, …)
2. When merged to \`main\`, release-drafter updates a draft release with auto-bumped tag (e.g. \`v0.0.2\`)
3. Publish the draft from the Releases page → \`release: published\` fires \`publish-react.yml\` → pushes to \`npm.pkg.github.com\`

## Notes

- \`release: published\` is used instead of tag push because \`GITHUB_TOKEN\`-created tags don't trigger push events (infinite-loop protection).
- The \`breaking\` / \`skip-changelog\` labels must be created on GitHub (e.g. via the sync-label workflow) before first use.
- Repository-level \`Settings → Actions → Workflow permissions → Read and write permissions\` must be enabled for the publish workflow.

## Test plan

- [ ] Verify \`release-drafter\` opens/updates a draft release after merging this PR to main
- [ ] Verify publishing the draft triggers \`publish-react.yml\`
- [ ] Verify \`@morinoparty/chlorophyll-react\` appears under the repo's GitHub Packages
- [ ] Verify all consumer packages (docs/storybook/cli) still resolve the renamed workspace dep