### PR TITLE
🎨 Load Satoshi font in Storybook & unify fg color tokens with color-mix

### DIFF
--- a/docs/app/routeTree.gen.ts
+++ b/docs/app/routeTree.gen.ts
@@ -8,132 +8,139 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ApiSearchRouteImport } from "./routes/api/search";
-import { Route as DocsSplatRouteImport } from "./routes/docs/$";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as LlmsFullDottxtRouteImport } from "./routes/llms-full[.]txt";
-import { Route as LlmsDottxtRouteImport } from "./routes/llms[.]txt";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsSplatRouteImport } from './routes/docs/$'
+import { Route as ApiSearchRouteImport } from './routes/api/search'
 
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
-    id: "/llms.txt",
-    path: "/llms.txt",
-    getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/llms.txt',
+  path: '/llms.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
-    id: "/llms-full.txt",
-    path: "/llms-full.txt",
-    getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/llms-full.txt',
+  path: '/llms-full.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-    id: "/",
-    path: "/",
-    getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DocsSplatRoute = DocsSplatRouteImport.update({
-    id: "/docs/$",
-    path: "/docs/$",
-    getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/docs/$',
+  path: '/docs/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
-    id: "/api/search",
-    path: "/api/search",
-    getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/search',
+  path: '/api/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-    "/": typeof IndexRoute;
-    "/llms-full.txt": typeof LlmsFullDottxtRoute;
-    "/llms.txt": typeof LlmsDottxtRoute;
-    "/api/search": typeof ApiSearchRoute;
-    "/docs/$": typeof DocsSplatRoute;
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRoutesByTo {
-    "/": typeof IndexRoute;
-    "/llms-full.txt": typeof LlmsFullDottxtRoute;
-    "/llms.txt": typeof LlmsDottxtRoute;
-    "/api/search": typeof ApiSearchRoute;
-    "/docs/$": typeof DocsSplatRoute;
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRoutesById {
-    __root__: typeof rootRouteImport;
-    "/": typeof IndexRoute;
-    "/llms-full.txt": typeof LlmsFullDottxtRoute;
-    "/llms.txt": typeof LlmsDottxtRoute;
-    "/api/search": typeof ApiSearchRoute;
-    "/docs/$": typeof DocsSplatRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRouteTypes {
-    fileRoutesByFullPath: FileRoutesByFullPath;
-    fullPaths: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$";
-    fileRoutesByTo: FileRoutesByTo;
-    to: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$";
-    id: "__root__" | "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$";
-    fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/llms-full.txt' | '/llms.txt' | '/api/search' | '/docs/$'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/llms-full.txt' | '/llms.txt' | '/api/search' | '/docs/$'
+  id:
+    | '__root__'
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-    IndexRoute: typeof IndexRoute;
-    LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute;
-    LlmsDottxtRoute: typeof LlmsDottxtRoute;
-    ApiSearchRoute: typeof ApiSearchRoute;
-    DocsSplatRoute: typeof DocsSplatRoute;
+  IndexRoute: typeof IndexRoute
+  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
+  ApiSearchRoute: typeof ApiSearchRoute
+  DocsSplatRoute: typeof DocsSplatRoute
 }
 
-declare module "@tanstack/react-router" {
-    interface FileRoutesByPath {
-        "/llms.txt": {
-            id: "/llms.txt";
-            path: "/llms.txt";
-            fullPath: "/llms.txt";
-            preLoaderRoute: typeof LlmsDottxtRouteImport;
-            parentRoute: typeof rootRouteImport;
-        };
-        "/llms-full.txt": {
-            id: "/llms-full.txt";
-            path: "/llms-full.txt";
-            fullPath: "/llms-full.txt";
-            preLoaderRoute: typeof LlmsFullDottxtRouteImport;
-            parentRoute: typeof rootRouteImport;
-        };
-        "/": {
-            id: "/";
-            path: "/";
-            fullPath: "/";
-            preLoaderRoute: typeof IndexRouteImport;
-            parentRoute: typeof rootRouteImport;
-        };
-        "/docs/$": {
-            id: "/docs/$";
-            path: "/docs/$";
-            fullPath: "/docs/$";
-            preLoaderRoute: typeof DocsSplatRouteImport;
-            parentRoute: typeof rootRouteImport;
-        };
-        "/api/search": {
-            id: "/api/search";
-            path: "/api/search";
-            fullPath: "/api/search";
-            preLoaderRoute: typeof ApiSearchRouteImport;
-            parentRoute: typeof rootRouteImport;
-        };
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
     }
+    '/llms-full.txt': {
+      id: '/llms-full.txt'
+      path: '/llms-full.txt'
+      fullPath: '/llms-full.txt'
+      preLoaderRoute: typeof LlmsFullDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/$': {
+      id: '/docs/$'
+      path: '/docs/$'
+      fullPath: '/docs/$'
+      preLoaderRoute: typeof DocsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/search': {
+      id: '/api/search'
+      path: '/api/search'
+      fullPath: '/api/search'
+      preLoaderRoute: typeof ApiSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
-    IndexRoute: IndexRoute,
-    LlmsFullDottxtRoute: LlmsFullDottxtRoute,
-    LlmsDottxtRoute: LlmsDottxtRoute,
-    ApiSearchRoute: ApiSearchRoute,
-    DocsSplatRoute: DocsSplatRoute,
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+  IndexRoute: IndexRoute,
+  LlmsFullDottxtRoute: LlmsFullDottxtRoute,
+  LlmsDottxtRoute: LlmsDottxtRoute,
+  ApiSearchRoute: ApiSearchRoute,
+  DocsSplatRoute: DocsSplatRoute,
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
-import type { createStart } from "@tanstack/react-start";
-import type { getRouter } from "./router.tsx";
-
-declare module "@tanstack/react-start" {
-    interface Register {
-        ssr: true;
-        router: Awaited<ReturnType<typeof getRouter>>;
-    }
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
 }

--- a/packages/react/src/preset/create-preset.ts
+++ b/packages/react/src/preset/create-preset.ts
@@ -37,7 +37,7 @@ export const createPreset = (option: PresetOptions) => {
                 backgroundColor: "colorPalette.5",
             },
             ".dark ::selection": {
-                backgroundColor: "colorPalette.dark.4",
+                backgroundColor: "colorPalette.dark.9/70",
             },
         },
         conditions: {

--- a/packages/react/src/preset/token/recipes/player-phrase-card.ts
+++ b/packages/react/src/preset/token/recipes/player-phrase-card.ts
@@ -25,14 +25,14 @@ export const playerPhraseCard = defineSlotRecipe({
         },
         phrase: {
             textStyle: "sm",
-            color: "colorPalette.fg.subtle/70",
+            color: "colorPalette.fg/70",
             fontWeight: "medium",
             lineHeight: "[1.2]",
         },
         name: {
             textStyle: "lg",
             marginTop: "1.5",
-            color: "colorPalette.fg.subtle",
+            color: "colorPalette.fg",
             fontWeight: "extrabold",
             fontVariationSettings: "'wght' 800",
             lineHeight: "[1.2]",

--- a/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
@@ -171,7 +171,7 @@ export const blue = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.blue.12}",
+                    _light: "color-mix(in oklch, {colors.blue.12}, {colors.blue.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
@@ -179,7 +179,7 @@ export const blue = defineSemanticTokens.colors({
                 value: "{colors.gray.11}",
             },
             subtle: {
-                value: "{colors.blue.11}",
+                value: "color-mix(in oklch, {colors.blue.11}, transparent 25%)",
             },
         },
         // Solid background

--- a/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
@@ -171,7 +171,7 @@ export const gray = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.gray.12}",
+                    _light: "color-mix(in oklch, {colors.gray.12}, {colors.gray.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
@@ -179,7 +179,7 @@ export const gray = defineSemanticTokens.colors({
                 value: "{colors.gray.11}",
             },
             subtle: {
-                value: "{colors.gray.11}",
+                value: "color-mix(in oklch, {colors.gray.11}, transparent 25%)",
             },
         },
         // Solid background

--- a/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
@@ -148,7 +148,10 @@ export const mori = defineSemanticTokens.colors({
         },
         bg: {
             DEFAULT: {
-                value: "{colors.mori.2}",
+                value: {
+                    _light: "{colors.mori.2}",
+                    _dark: "{colors.mori.2}",
+                },
             },
             subtle: {
                 value: "{colors.mori.1}",
@@ -168,12 +171,12 @@ export const mori = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.mori.12}",
+                    _light: "color-mix(in oklch, {colors.mori.12}, {colors.mori.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
             subtle: {
-                value: "{colors.mori.11}",
+                value: "color-mix(in oklch, {colors.mori.11}, transparent 30%)",
             },
             muted: {
                 value: "{colors.gray.11}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/red.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/red.ts
@@ -171,7 +171,7 @@ export const red = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.red.12}",
+                    _light: "color-mix(in oklch, {colors.red.12}, {colors.red.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
@@ -179,7 +179,7 @@ export const red = defineSemanticTokens.colors({
                 value: "{colors.gray.11}",
             },
             subtle: {
-                value: "{colors.red.11}",
+                value: "color-mix(in oklch, {colors.red.11}, transparent 25%)",
             },
         },
         // Solid background

--- a/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
@@ -171,7 +171,7 @@ export const umi = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.umi.12}",
+                    _light: "color-mix(in oklch, {colors.umi.12}, {colors.umi.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
@@ -179,7 +179,7 @@ export const umi = defineSemanticTokens.colors({
                 value: "{colors.gray.11}",
             },
             subtle: {
-                value: "{colors.umi.11}",
+                value: "color-mix(in oklch, {colors.umi.11}, transparent 25%)",
             },
         },
         // Solid background

--- a/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
@@ -171,7 +171,7 @@ export const yellow = defineSemanticTokens.colors({
         fg: {
             DEFAULT: {
                 value: {
-                    _light: "{colors.yellow.12}",
+                    _light: "color-mix(in oklch, {colors.yellow.12}, {colors.yellow.11} 70%)",
                     _dark: "{colors.white}",
                 },
             },
@@ -179,7 +179,7 @@ export const yellow = defineSemanticTokens.colors({
                 value: "{colors.gray.11}",
             },
             subtle: {
-                value: "{colors.yellow.11}",
+                value: "color-mix(in oklch, {colors.yellow.11}, transparent 25%)",
             },
         },
         // Solid background

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -1,3 +1,4 @@
+<link href="https://api.fontshare.com/v2/css?f[]=satoshi@1&display=swap" rel="stylesheet">
 <link href="https://shogo82148.github.io/genjyuugothic-subsets/GenJyuuGothicL-P-Medium/GenJyuuGothicL-P-Medium.css" type="text/css" rel="stylesheet">
 <link href="https://shogo82148.github.io/genjyuugothic-subsets/GenJyuuGothicL-P-Bold/GenJyuuGothicL-P-Bold.css" type="text/css" rel="stylesheet">
 


### PR DESCRIPTION
## 概要

Storybook で英字フォントが Satoshi Variable ではなく GenJyuuGothic にフォールバックしていた問題を修正し、あわせて全カラーパレットの `fg` セマンティックトークンを color-mix ベースに統一しました。

## 背景・問題

`textStyle.body` の `font-family` は `'Satoshi', 'GenJyuuGothicLP', ...` と Satoshi を先頭に指定していましたが、Storybook の `preview-head.html` が GenJyuuGothic の CSS しか読み込んでおらず、**Satoshi が一切ロードされていなかった**ため、英字も GenJyuu にフォールバックしていました。

## 変更内容

### フォント
- `storybook/.storybook/preview-head.html` に Satoshi（fontshare、docs の `__root.tsx` と同一 URL）の `<link>` を追加

### カラートークン
- 全6パレット（mori / umi / blue / red / yellow / gray）の `fg` を color-mix ベースに統一
  - `fg.DEFAULT._light`: `color-mix(in oklch, {colors.X.12}, {colors.X.11} 30%)`
  - `fg.subtle`: `color-mix(in oklch, {colors.X.11}, transparent 25%)`
  - `_dark`（白）と `muted` は据え置き

## 検証

Playwright で Storybook（全パレット）を確認:

- **フォント**: Satoshi が可変フォント（300–900）としてロードされ、英字 `"Chlorophyll Button"` の描画幅が GenJyuu（379px）と別物（328px）になることを確認。日本語「次へ」は GenJyuu のまま。
- **カラートークン**: 全6パレットで `fg` / `fg-subtle` が color-mix 由来の oklch 値（subtle は α=0.75）に解決されることを確認。

`pnpm panda codegen` / Biome チェックも通過済み。

> ⚠️ `preview-head.html` は静的ファイルのため、稼働中の Storybook に完全反映するにはサーバー再起動が必要な場合があります。
