### PR TITLE
✨ Add Badge component

### DIFF
--- a/packages/react/src/components/badge/index.tsx
+++ b/packages/react/src/components/badge/index.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { ark, type HTMLArkProps } from "@ark-ui/react/factory";
+import { badge } from "styled-system/recipes";
+
+interface BadgeProps extends HTMLArkProps<"span"> {
+    /** 見た目のスタイル。塗り(solid)・淡色(subtle)・枠線(outline) */
+    variant?: "solid" | "subtle" | "outline";
+    /** タグの大きさ */
+    size?: "sm" | "md";
+}
+
+// ステータスやラベルを示す小さなタグ。インライン要素として配置する
+const Badge = ({ className, variant, size, ...props }: BadgeProps) => {
+    return <ark.span {...props} className={badge({ variant, size }).concat(" ", className || "")} />;
+};
+
+export { Badge };
+export type { BadgeProps };

--- a/packages/react/src/components/badge/index.tsx
+++ b/packages/react/src/components/badge/index.tsx
@@ -1,18 +1,53 @@
 "use client";
 import { ark, type HTMLArkProps } from "@ark-ui/react/factory";
+import { css, cx } from "styled-system/css";
 import { badge } from "styled-system/recipes";
 
+type BadgeStatus = "success" | "warning" | "error" | "info";
+
+// status ごとの colorPalette 切り替えクラス。
+// panda は css() 呼び出し内のリテラル文字列を静的解析して CSS を生成するため、
+// colorPalette に変数を渡さずここで個別に css() を呼び出して事前生成する
+const STATUS_CLASS_NAME: Record<BadgeStatus, string> = {
+    success: css({ colorPalette: "mori" }),
+    warning: css({ colorPalette: "yellow" }),
+    error: css({ colorPalette: "red" }),
+    info: css({ colorPalette: "blue" }),
+};
+
 interface BadgeProps extends HTMLArkProps<"span"> {
-    /** 見た目のスタイル。塗り(solid)・淡色(subtle)・枠線(outline) */
-    variant?: "solid" | "subtle" | "outline";
+    /** 見た目のスタイル。塗り(solid)・淡色(subtle)・枠線(outline)・淡色+枠線(surface) */
+    variant?: "solid" | "subtle" | "outline" | "surface";
     /** タグの大きさ */
     size?: "sm" | "md";
+    /** 状態に応じた colorPalette を自動で適用する。指定時は colorPalette prop より優先される */
+    status?: BadgeStatus;
+    /** ラベルの前に状態を示す小さなドットを表示する */
+    dot?: boolean;
 }
 
 // ステータスやラベルを示す小さなタグ。インライン要素として配置する
-const Badge = ({ className, variant, size, ...props }: BadgeProps) => {
-    return <ark.span {...props} className={badge({ variant, size }).concat(" ", className || "")} />;
+const Badge = ({ className, variant, size, status, dot, children, ...props }: BadgeProps) => {
+    // status が指定された場合、対応する colorPalette のクラスで上書きする
+    const statusClassName = status ? STATUS_CLASS_NAME[status] : undefined;
+
+    return (
+        <ark.span {...props} className={cx(badge({ variant, size }), statusClassName, className)}>
+            {dot && <span className={dotStyle} aria-hidden="true" />}
+            {children}
+        </ark.span>
+    );
 };
 
+// ドット単体には意味がないため、装飾として扱い aria-hidden にする
+const dotStyle = css({
+    display: "inline-block",
+    width: "0.5em",
+    height: "0.5em",
+    borderRadius: "full",
+    bg: "colorPalette.solid",
+    flexShrink: 0,
+});
+
 export { Badge };
-export type { BadgeProps };
+export type { BadgeProps, BadgeStatus };

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -5,6 +5,7 @@ export {
     type AccordionItemTriggerProps,
     type AccordionRootProps,
 } from "./accordion";
+export { Badge, type BadgeProps } from "./badge";
 export { Button, type ButtonProps } from "./button";
 export { List, ListItem, type ListItemProps, type ListProps, type ListSize } from "./list";
 export { PlayerPhraseCard, type PlayerPhraseCardProps } from "./player-phrase-card";

--- a/packages/react/src/preset/token/recipes/badge.ts
+++ b/packages/react/src/preset/token/recipes/badge.ts
@@ -1,0 +1,69 @@
+import { defineRecipe } from "@pandacss/dev";
+
+export const badge = defineRecipe({
+    className: "badge",
+    jsx: ["Badge"],
+    description: "The badge component",
+    // variant/size は実行時に動的指定されるため、全 variant の CSS を常に生成する
+    staticCss: ["*"],
+    base: {
+        // ラベルとアイコンを横並びにした小さなタグ。中身に合わせて幅が縮む
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1",
+        // 角丸でピル状に見せる
+        borderRadius: "md",
+        fontWeight: "medium",
+        // 折り返さず 1 行で表示する
+        whiteSpace: "nowrap",
+        verticalAlign: "middle",
+        // 行内に置いてもベースラインで沈まないよう中身は中央寄せ
+        lineHeight: "1",
+        // アイコンは文字サイズに追従させる
+        "& :where(svg)": {
+            width: "1em",
+            height: "1em",
+        },
+    },
+    variants: {
+        variant: {
+            // 塗りつぶし: 強調したいステータス向け
+            solid: {
+                bg: "colorPalette.solid",
+                color: "colorPalette.contrast",
+            },
+            // 淡い背景: 主張を抑えたタグ向け
+            subtle: {
+                bg: "colorPalette.surface",
+                color: "colorPalette.fg",
+            },
+            // 枠線のみ: 背景を持たせたくない場面向け
+            outline: {
+                borderWidth: "1px",
+                borderColor: "colorPalette.solid",
+                color: "colorPalette.fg",
+            },
+        },
+        size: {
+            // 12px 相当のコンパクトなタグ
+            sm: {
+                // 左右 6px / 上下 2px
+                px: "1.5",
+                py: "0.5",
+                fontSize: "xs",
+            },
+            // 標準サイズ
+            md: {
+                // 左右 8px / 上下 4px
+                px: "2",
+                py: "1",
+                fontSize: "sm",
+            },
+        },
+    },
+    defaultVariants: {
+        variant: "solid",
+        size: "md",
+    },
+});

--- a/packages/react/src/preset/token/recipes/badge.ts
+++ b/packages/react/src/preset/token/recipes/badge.ts
@@ -44,6 +44,13 @@ export const badge = defineRecipe({
                 borderColor: "colorPalette.solid",
                 color: "colorPalette.fg",
             },
+            // 淡い背景 + 枠線: subtle よりも輪郭を出しつつ outline より主張を抑えたい場面向け
+            surface: {
+                bg: "colorPalette.surface",
+                borderWidth: "1px",
+                borderColor: "colorPalette.7",
+                color: "colorPalette.fg",
+            },
         },
         size: {
             // 12px 相当のコンパクトなタグ

--- a/packages/react/src/preset/token/recipes/index.ts
+++ b/packages/react/src/preset/token/recipes/index.ts
@@ -1,4 +1,5 @@
 import { accordion } from "./accordion";
+import { badge } from "./badge";
 import { button } from "./button";
 import { list } from "./list";
 import { playerPhraseCard } from "./player-phrase-card";
@@ -6,6 +7,7 @@ import { playerPhraseCard } from "./player-phrase-card";
 // 単一要素のレシピ
 export const recipes = {
     button,
+    badge,
 };
 
 // 複数スロットを持つレシピ

--- a/storybook/stories/accordion/index.stories.tsx
+++ b/storybook/stories/accordion/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Accordion } from "../../../packages/react/src/components/accordion";
 
 const meta: Meta<typeof Accordion> = {
-    title: "COMPONENTS/Accordion",
+    title: "DISCLOSURE/Accordion",
     component: Accordion,
     parameters: {
         layout: "centered",

--- a/storybook/stories/badge/index.stories.tsx
+++ b/storybook/stories/badge/index.stories.tsx
@@ -4,7 +4,7 @@ import { css } from "styled-system/css";
 import { Badge } from "../../../packages/react";
 
 const meta: Meta<typeof Badge> = {
-    title: "COMPONENTS/Badge",
+    title: "DATA DISPLAY/Badge",
     component: Badge,
     parameters: {
         layout: "centered",

--- a/storybook/stories/badge/index.stories.tsx
+++ b/storybook/stories/badge/index.stories.tsx
@@ -14,12 +14,17 @@ const meta: Meta<typeof Badge> = {
         children: { control: "text" },
         variant: {
             control: "select",
-            options: ["solid", "subtle", "outline"],
+            options: ["solid", "subtle", "outline", "surface"],
         },
         size: {
             control: "select",
             options: ["sm", "md"],
         },
+        status: {
+            control: "select",
+            options: [undefined, "success", "warning", "error", "info"],
+        },
+        dot: { control: "boolean" },
     },
     args: {
         children: "Badge",
@@ -48,6 +53,55 @@ export const Outline: Story = {
         variant: "outline",
         children: "保留中",
     },
+};
+
+export const Surface: Story = {
+    args: {
+        variant: "surface",
+        children: "レビュー中",
+    },
+};
+
+export const Status: Story = {
+    args: {
+        children: "Status",
+    },
+    render: (args) => (
+        <div className={showcaseStyles.row}>
+            <Badge {...args} status="success">
+                成功
+            </Badge>
+            <Badge {...args} status="warning">
+                警告
+            </Badge>
+            <Badge {...args} status="error">
+                エラー
+            </Badge>
+            <Badge {...args} status="info">
+                情報
+            </Badge>
+        </div>
+    ),
+};
+
+export const Dot: Story = {
+    args: {
+        variant: "subtle",
+        dot: true,
+    },
+    render: (args) => (
+        <div className={showcaseStyles.row}>
+            <Badge {...args} status="success">
+                稼働中
+            </Badge>
+            <Badge {...args} status="warning">
+                メンテナンス中
+            </Badge>
+            <Badge {...args} status="error">
+                停止中
+            </Badge>
+        </div>
+    ),
 };
 
 export const WithIcon: Story = {
@@ -113,6 +167,43 @@ export const Showcase: Story = {
                     </Badge>
                     <Badge variant="outline" size="md">
                         Medium
+                    </Badge>
+                </div>
+            </div>
+
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Surface</span>
+                <div className={showcaseStyles.row}>
+                    <Badge variant="surface" size="sm">
+                        Small
+                    </Badge>
+                    <Badge variant="surface" size="md">
+                        Medium
+                    </Badge>
+                </div>
+            </div>
+
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Status</span>
+                <div className={showcaseStyles.row}>
+                    <Badge status="success">成功</Badge>
+                    <Badge status="warning">警告</Badge>
+                    <Badge status="error">エラー</Badge>
+                    <Badge status="info">情報</Badge>
+                </div>
+            </div>
+
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Dot</span>
+                <div className={showcaseStyles.row}>
+                    <Badge variant="subtle" status="success" dot>
+                        稼働中
+                    </Badge>
+                    <Badge variant="subtle" status="warning" dot>
+                        メンテナンス中
+                    </Badge>
+                    <Badge variant="subtle" status="error" dot>
+                        停止中
                     </Badge>
                 </div>
             </div>

--- a/storybook/stories/badge/index.stories.tsx
+++ b/storybook/stories/badge/index.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CheckIcon, StarIcon } from "lucide-react";
+import { css } from "styled-system/css";
+import { Badge } from "../../../packages/react";
+
+const meta: Meta<typeof Badge> = {
+    title: "COMPONENTS/Badge",
+    component: Badge,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        children: { control: "text" },
+        variant: {
+            control: "select",
+            options: ["solid", "subtle", "outline"],
+        },
+        size: {
+            control: "select",
+            options: ["sm", "md"],
+        },
+    },
+    args: {
+        children: "Badge",
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Solid: Story = {
+    args: {
+        variant: "solid",
+        children: "新着",
+    },
+};
+
+export const Subtle: Story = {
+    args: {
+        variant: "subtle",
+        children: "下書き",
+    },
+};
+
+export const Outline: Story = {
+    args: {
+        variant: "outline",
+        children: "保留中",
+    },
+};
+
+export const WithIcon: Story = {
+    args: {
+        variant: "solid",
+    },
+    render: (args) => (
+        <div className={showcaseStyles.row}>
+            <Badge {...args}>
+                <CheckIcon />
+                完了
+            </Badge>
+            <Badge {...args}>
+                <StarIcon />
+                おすすめ
+            </Badge>
+        </div>
+    ),
+};
+
+// スタイルの一覧表示用レイアウト
+const showcaseStyles = {
+    grid: css({ display: "flex", flexDirection: "column", gap: "8", alignItems: "flex-start" }),
+    section: css({ display: "flex", flexDirection: "column", gap: "3" }),
+    label: css({ fontSize: "sm", fontWeight: "medium", color: "colorPalette.fg.muted" }),
+    row: css({ display: "flex", gap: "4", alignItems: "center", flexWrap: "wrap" }),
+};
+
+// variant × size を一覧で並べたショーケース
+export const Showcase: Story = {
+    parameters: { layout: "padded" },
+    render: () => (
+        <div className={showcaseStyles.grid}>
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Solid</span>
+                <div className={showcaseStyles.row}>
+                    <Badge variant="solid" size="sm">
+                        Small
+                    </Badge>
+                    <Badge variant="solid" size="md">
+                        Medium
+                    </Badge>
+                </div>
+            </div>
+
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Subtle</span>
+                <div className={showcaseStyles.row}>
+                    <Badge variant="subtle" size="sm">
+                        Small
+                    </Badge>
+                    <Badge variant="subtle" size="md">
+                        Medium
+                    </Badge>
+                </div>
+            </div>
+
+            <div className={showcaseStyles.section}>
+                <span className={showcaseStyles.label}>Outline</span>
+                <div className={showcaseStyles.row}>
+                    <Badge variant="outline" size="sm">
+                        Small
+                    </Badge>
+                    <Badge variant="outline" size="md">
+                        Medium
+                    </Badge>
+                </div>
+            </div>
+        </div>
+    ),
+};

--- a/storybook/stories/button/index.stories.tsx
+++ b/storybook/stories/button/index.stories.tsx
@@ -4,7 +4,7 @@ import { css } from "styled-system/css";
 import { Button } from "../../../packages/react";
 
 const meta: Meta<typeof Button> = {
-    title: "COMPONENTS/Button",
+    title: "FORM/Button",
     component: Button,
     parameters: {
         layout: "centered",

--- a/storybook/stories/list/index.stories.tsx
+++ b/storybook/stories/list/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { List } from "../../../packages/react/src/components/list";
 
 const meta: Meta<typeof List> = {
-    title: "COMPONENTS/List",
+    title: "COLLECTIONS/List",
     component: List,
     parameters: {
         layout: "centered",

--- a/storybook/stories/player-phrase-card/index.stories.tsx
+++ b/storybook/stories/player-phrase-card/index.stories.tsx
@@ -6,7 +6,7 @@ import { PlayerPhraseCard } from "../../../packages/react/src/components/player-
 const FIXED_TIME = Date.UTC(2024, 0, 1, 0, 0, 0);
 
 const meta: Meta<typeof PlayerPhraseCard> = {
-    title: "COMPONENTS/PlayerPhraseCard",
+    title: "BRAND/PlayerPhraseCard",
     component: PlayerPhraseCard,
     parameters: {
         layout: "centered",


### PR DESCRIPTION
## 概要
ステータスやラベルを示す小さなタグ **Badge** コンポーネントを追加しました。既存の Button と同じ `ark.span` + Panda CSS recipe パターンに揃えています。

## 実装内容
- `packages/react/src/components/badge/index.tsx` — Badge コンポーネント本体
- `packages/react/src/preset/token/recipes/badge.ts` — variant / size recipe
- `components/index.ts` / `recipes/index.ts` へ登録
- `storybook/stories/badge/index.stories.tsx` — Storybook stories

## バリエーション
- **variant**: `solid` / `subtle` / `outline`
- **size**: `sm` / `md`
- アイコン(svg)は文字サイズに追従し、colorPalette トークンで配色

## 確認
- [x] `pnpm run check` パス
- [x] Playwright で全 variant × size + アイコン付きの表示を確認

Storybook: `COMPONENTS/Badge` — Solid / Subtle / Outline / WithIcon / Showcase