### PR TITLE
✨ Add secondary tokens & ghost variant for Accordion/List

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,85 @@
-# 🌿 Chlorophyll 🌿
+# 🌿 Chlorophyll
+
+[![Documentation](https://shieldcn.dev/badge/Documentation-read-396E56.svg?logo=readthedocs&logoColor=white)][docs]
+[![Storybook](https://shieldcn.dev/badge/Storybook-live-FF4785.svg?logo=storybook&logoColor=white)][storybook]
+[![GitHub Packages](https://shieldcn.dev/badge/GitHub_Packages-chlorophyll--react-181717.svg?logo=github&logoColor=white)][npm]
 
 > [!WARNING]
 > This project is currently under development.
 
-## ✨ About the Project
-Chlorophyll is a modern and user-friendly UI component library built with React and TypeScript.
+A modern UI component library for React, built with TypeScript, Panda CSS, and Ark UI.
 
 ## 🛠 Tech Stack
-- 🎨 **Language**: TypeScript
-- ⚛️ **Framework**: React
-- 🎯 **CSS Library**: PandaCSS
-- 🎭 **Headless Library**: Ark UI
 
-## 🚀 Setting Up the Development Environment
-
-### 🎯 Check UI Components
-```bash
-pnpm run dev
-```
-
-## 🧪 Testing
-
-### Install dependencies
-```bash
-pnpm dlx playwright install --with-deps
-```
-
-### 🎯 Check UI Components
-```bash
-pnpm run test:runner
-```
-
-### 🎯 Check VRT
-```bash
-pnpm run test:vrt
-```
-
+**TypeScript** · **React** · **Panda CSS** · **Ark UI**
 
 ## 📦 Installation
 
-1. Install PandaCSS
+The package is hosted on GitHub Packages. Point the `@morinoparty` scope at the registry in your `.npmrc`:
 
-[Getting Started - PandaCSS](https://panda-css.com/docs/overview/getting-started#framework-guides)
-
-2. Install React Aria
-```bash
-pnpm add 
-
-3. Install the Panda Preset
-```bash
-pnpm add @ark-ui/react
+```ini
+@morinoparty:registry=https://npm.pkg.github.com
 ```
 
+```bash
+pnpm add @morinoparty/chlorophyll-react
+```
+
+Add the Panda preset to `panda.config.ts`:
+
 ```ts
-import { defineConfig } from '@pandacss/dev'
-import { createPreset } from '@moripa/chlorophyll-preset'
-import mori from '@moripa/chlorophyll-preset/colors/accent/mori'
-import stone from '@moripa/chlorophyll-preset/colors/base/stone'
+import { defineConfig } from "@pandacss/dev";
+import { createPreset, stone } from "@morinoparty/chlorophyll-react/preset";
 
 export default defineConfig({
   preflight: true,
-  presets: [createPreset({ accentColor: mori, grayColor: stone, radius: 'sm' })],
-  include: ['./src/**/*.{js,jsx,ts,tsx}'],
-  jsxFramework: 'react',
-  outdir: 'styled-system',
-})
+  presets: ["@pandacss/preset-base", createPreset({ brandColor: "mori", grayColor: stone, radius: "md" })],
+  include: ["./src/**/*.{ts,tsx}"],
+  jsxFramework: "react",
+  outdir: "styled-system",
+});
 ```
-
-4. Path alias
-tsconfig.json
-```json
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@styled-system/*": ["./styled-system/*"]
-    }
-  }
-}
-```
-
 
 ## 📖 Usage
-```tsx
-import { Button } from '@moripa/chlorophyll';
 
-function App() {
-  return (
-    <Button>Click me!</Button>
-  );
+```tsx
+import { Button } from "@morinoparty/chlorophyll-react";
+
+export function App() {
+  return <Button>Click me!</Button>;
 }
 ```
 
-[token](https://946d07e9-color-palette.nikomaru.workers.dev/?min=0.1&max=0.98&length=15&chroma=0.085&data=[{%22colorValue%22%3A%22rgba(57%2C+110%2C+86%2C+1)%22%2C%22colorId%22%3A%22mori%22%2C%22uniqueId%22%3A1}%2C{%22colorValue%22%3A%22rgba(59%2C+149%2C+155%2C+1)%22%2C%22colorId%22%3A%22umi%22%2C%22uniqueId%22%3A2}])
+See the [documentation][docs] and [Storybook][storybook] for the full component list and design tokens.
 
-## 🤝 Contribution
-Contributions are welcome! Follow these steps to participate:
+## 🚀 Development
+
+```bash
+pnpm install
+pnpm dev            # all packages
+pnpm dev:docs       # docs only
+pnpm dev:storybook  # storybook only
+```
+
+### Testing
+
+```bash
+pnpm dlx playwright install --with-deps
+pnpm test           # component tests
+pnpm test:vrt       # visual regression tests
+```
+
+## 🤝 Contributing
 
 1. Fork this repository
 2. Create a new branch
 3. Commit your changes
-4. Create a pull request
+4. Open a pull request
+
+[docs]: https://chlorophyll-docs.nikomaru.workers.dev/docs/getting-started/introduction/
+[storybook]: https://chlorophyll-storybook.nikomaru.workers.dev
+[npm]: https://github.com/morinoparty/chlorophyll/pkgs/npm/chlorophyll-react
 
 ---
-Made with 💚 by Morino party team
+
+Made with 💚 by Morino Party

--- a/packages/react/src/components/accordion/index.tsx
+++ b/packages/react/src/components/accordion/index.tsx
@@ -4,14 +4,22 @@ import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { accordion } from "styled-system/recipes";
 
-// variant を持たないためスロットクラスは一度だけ解決すれば済む
+// root 以外のスロットは variant に依存しないため一度だけ解決すれば済む
 const styles = accordion();
 
-type AccordionRootProps = ComponentProps<typeof ArkAccordion.Root>;
+// パネル(白カード)か、背景を透過してページ地に馴染ませる ghost か
+type AccordionVariant = "panel" | "ghost";
+
+type AccordionRootProps = ComponentProps<typeof ArkAccordion.Root> & {
+    /** 背景の見せ方。panel(白カード) / ghost(背景透過) */
+    variant?: AccordionVariant;
+};
 
 // アコーディオン全体を包むパネル
-const AccordionRoot = ({ className, ...props }: AccordionRootProps) => {
-    return <ArkAccordion.Root {...props} className={styles.root.concat(" ", className || "")} />;
+const AccordionRoot = ({ className, variant = "panel", ...props }: AccordionRootProps) => {
+    // 背景色は variant で変わるため root だけ variant 込みで解決する
+    const rootClass = accordion({ variant }).root;
+    return <ArkAccordion.Root {...props} className={rootClass.concat(" ", className || "")} />;
 };
 
 type AccordionItemProps = ComponentProps<typeof ArkAccordion.Item>;
@@ -51,4 +59,10 @@ const Accordion = Object.assign(AccordionRoot, {
 });
 
 export { Accordion };
-export type { AccordionRootProps, AccordionItemProps, AccordionItemTriggerProps, AccordionItemContentProps };
+export type {
+    AccordionRootProps,
+    AccordionItemProps,
+    AccordionItemTriggerProps,
+    AccordionItemContentProps,
+    AccordionVariant,
+};

--- a/packages/react/src/components/list/index.tsx
+++ b/packages/react/src/components/list/index.tsx
@@ -5,6 +5,8 @@ import { createContext, type ReactNode, useContext } from "react";
 import { list } from "styled-system/recipes";
 
 type ListSize = "sm" | "md";
+// パネル(白カード)か、背景を透過してページ地に馴染ませる ghost か
+type ListVariant = "panel" | "ghost";
 
 // Root で指定した size を Item にも伝えるための Context。
 // Compound Component なので Root と Item で同じ variant を共有する
@@ -13,11 +15,13 @@ const ListContext = createContext<ListSize>("md");
 interface ListProps extends HTMLArkProps<"div"> {
     /** リスト全体の大きさ。Item にも引き継がれる */
     size?: ListSize;
+    /** 背景の見せ方。panel(白カード) / ghost(背景透過) */
+    variant?: ListVariant;
 }
 
 // リスト全体を包むパネル。中に ListItem を並べて使う
-const ListRoot = ({ className, children, size = "md", ...props }: ListProps) => {
-    const styles = list({ size });
+const ListRoot = ({ className, children, size = "md", variant = "panel", ...props }: ListProps) => {
+    const styles = list({ size, variant });
 
     return (
         <ListContext.Provider value={size}>
@@ -54,4 +58,4 @@ const List = Object.assign(ListRoot, {
 });
 
 export { List, ListItem };
-export type { ListProps, ListItemProps, ListSize };
+export type { ListProps, ListItemProps, ListSize, ListVariant };

--- a/packages/react/src/preset/token/recipes/accordion.ts
+++ b/packages/react/src/preset/token/recipes/accordion.ts
@@ -8,10 +8,9 @@ export const accordion = defineSlotRecipe({
     slots: ["root", "item", "itemTrigger", "itemContent", "itemIndicator"],
     base: {
         root: {
-            // List と同じく白いパネルにまとめ、角丸でカード状に見せる
+            // 角丸でカード状に見せる。背景色は variant(panel/ghost)で切り替える
             display: "flex",
             flexDirection: "column",
-            bg: "bg.panel",
             borderRadius: "2xl",
             // 角丸からはみ出す trigger の hover 背景を切り取る
             overflow: "hidden",
@@ -88,6 +87,22 @@ export const accordion = defineSlotRecipe({
                 animationTimingFunction: "easeOut",
             },
         },
+    },
+    variants: {
+        // 背景の見せ方。白いカードにまとめる panel と、
+        // 背景を透過してページ地の上に直接並べる ghost を用意する
+        variant: {
+            panel: {
+                root: { bg: "bg.panel" },
+            },
+            ghost: {
+                // 親の背景をそのまま透かし、区切り線だけで項目を仕切る
+                root: { bg: "transparent" },
+            },
+        },
+    },
+    defaultVariants: {
+        variant: "panel",
     },
     // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
     staticCss: ["*"],

--- a/packages/react/src/preset/token/recipes/list.ts
+++ b/packages/react/src/preset/token/recipes/list.ts
@@ -9,10 +9,9 @@ export const list = defineSlotRecipe({
     slots: ["root", "item", "label", "icon"],
     base: {
         root: {
-            // Figma: 白いパネルの上に行を縦に並べたナビゲーション用リスト
+            // 行を縦に並べたナビゲーション用リスト。背景色は variant で切り替える
             display: "flex",
             flexDirection: "column",
-            bg: "bg.panel",
             // 16px = radii.2xl。角丸でカード状に見せる
             borderRadius: "2xl",
             // パネル端の余白は item 側に含めるため root には padding を持たせない。
@@ -67,6 +66,16 @@ export const list = defineSlotRecipe({
         },
     },
     variants: {
+        // 背景の見せ方。白いカードにまとめる panel と、
+        // 背景を透過してページ地の上に直接並べる ghost を用意する
+        variant: {
+            panel: {
+                root: { bg: "bg.panel" },
+            },
+            ghost: {
+                root: { bg: "transparent" },
+            },
+        },
         size: {
             // Figma 準拠の標準サイズ
             md: {
@@ -103,6 +112,7 @@ export const list = defineSlotRecipe({
         },
     },
     defaultVariants: {
+        variant: "panel",
         size: "md",
     },
     // 利用者側で動的に使われても CSS が出るよう全 variant を生成する

--- a/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
@@ -156,6 +156,10 @@ export const mori = defineSemanticTokens.colors({
             subtle: {
                 value: "{colors.mori.1}",
             },
+            // button.secondary の塗り面として使う想定の、mori を効かせた背景色
+            secondary: {
+                value: "{colors.mori.10}",
+            },
         },
         surface: {
             DEFAULT: {
@@ -180,6 +184,10 @@ export const mori = defineSemanticTokens.colors({
             },
             muted: {
                 value: "{colors.gray.11}",
+            },
+            // bg.secondary（濃い mori）の上に載せる前景色。白抜きで読ませる
+            secondary: {
+                value: "{colors.white}",
             },
         },
         solid: {

--- a/storybook/stories/accordion/index.stories.tsx
+++ b/storybook/stories/accordion/index.stories.tsx
@@ -53,6 +53,23 @@ export const Multiple: Story = {
     ),
 };
 
+// 背景を透過する ghost variant。
+// 白カードを敷かず、preview が塗るページの地色(colorPalette.bg)に直接馴染ませて見せる
+export const Ghost: Story = {
+    render: () => (
+        <div style={{ width: PANEL_WIDTH }}>
+            <Accordion.Root variant="ghost" defaultValue={["send"]} collapsible>
+                {items.map((item) => (
+                    <Accordion.Item key={item.value} value={item.value}>
+                        <Accordion.ItemTrigger>{item.title}</Accordion.ItemTrigger>
+                        <Accordion.ItemContent>{item.body}</Accordion.ItemContent>
+                    </Accordion.Item>
+                ))}
+            </Accordion.Root>
+        </div>
+    ),
+};
+
 // disabled な項目を含む
 export const WithDisabled: Story = {
     render: () => (

--- a/storybook/stories/list/index.stories.tsx
+++ b/storybook/stories/list/index.stories.tsx
@@ -81,6 +81,20 @@ export const Clickable: Story = {
     ),
 };
 
+// 背景を透過する ghost variant。
+// 白カードを敷かず、preview が塗るページの地色(colorPalette.bg)に直接馴染ませて見せる
+export const Ghost: Story = {
+    render: () => (
+        <div style={{ width: PANEL_WIDTH }}>
+            <List.Root variant="ghost">
+                <List.Item>誰かに送る</List.Item>
+                <List.Item>口座の記録</List.Item>
+                <List.Item>貯める</List.Item>
+            </List.Root>
+        </div>
+    ),
+};
+
 // disabled な行を含むサンプル
 export const WithDisabled: Story = {
     render: () => (


### PR DESCRIPTION
## 概要

`button.secondary` 用途を見据えた secondary 系トークンの追加と、Accordion / List に背景透過の `ghost` variant を追加したのだ。あわせて README を簡潔に書き直したのだ。

## 変更内容

### 🎨 system token(`colors/base/mori.ts`)
- `colorPalette.bg.secondary` = `mori.10`(濃い緑の面)
- `colorPalette.fg.secondary` = `white`(その面に載せる前景色)
- 意図: `button.secondary`(白パネルのボタン)を濃い緑の背景の上に置く場面で使う想定

### 🧩 Accordion / List に `ghost` variant を追加
- recipe に `variant: { panel, ghost }` を新設
  - `panel`(default): 従来どおり白カード(`bg.panel`)。既存の見た目は不変
  - `ghost`: 背景を透過し、親の地色に直接馴染ませる
- コンポーネントに `variant` prop(`"panel" | "ghost"`)を追加
- Storybook に `Ghost` ストーリーを追加

### 📝 README を書き直し
- 冒頭に **Documentation / Storybook / GitHub Packages** のバッジリンクを追加([shieldcn.dev](https://shieldcn.dev/) 製)
- 壊れていた Installation 手順(空の `pnpm add`・誤った preset import 等)を実際のパッケージ名・使い方に修正
- 存在しないテストコマンドを実際の `pnpm test` / `pnpm test:vrt` に修正し、全体を簡潔化

## 確認

- `styled-system` 再生成後、`variant_ghost` クラスと `colorPalette.*.secondary` トークンが出力されることを確認
- Storybook(6006)で Accordion/List の `ghost` 表示を目視確認
- バッジURLが `200 image/svg+xml` を返すことを確認

## 備考
- `button` の recipe / story は最終的に変更なし(元の状態を維持)