### PR TITLE
✨ Add PlayerMap marker chip component

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -17,6 +17,7 @@ export {
     type ResolvedMinecraftItem,
 } from "./minecraft-item";
 export { PlayerAvatar, type PlayerAvatarProps, type PlayerAvatarSize } from "./player-avatar";
+export { PlayerMap, type PlayerMapProps, type PlayerMapSize } from "./player-map";
 export {
     PlayerPhraseCard,
     type PlayerPhraseCardBodyProps,

--- a/packages/react/src/components/player-map/index.tsx
+++ b/packages/react/src/components/player-map/index.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { playerMap } from "styled-system/recipes";
+import { PlayerAvatar, type PlayerAvatarSize } from "../player-avatar";
+
+// チップの大きさ。中の PlayerAvatar のサイズにそのまま対応させる
+type PlayerMapSize = PlayerAvatarSize;
+
+interface PlayerMapProps {
+    /** プレイヤーの UUID。PlayerAvatar 経由でアバター画像の取得に使う */
+    playerId: string;
+    /** プレイヤー名。アバターの alt とチップに並べるラベルの両方に使う */
+    playerName: string;
+    /** チップの大きさ */
+    size?: PlayerMapSize;
+}
+
+// 地図上に置くプレイヤーマーカー。PlayerAvatar(#48) の顔アイコンに名前を添えた、
+// 白フチ + 薄緑のチップ。地図のどんな背景に載せても浮いて見えるようにする
+const PlayerMap = ({ playerId, playerName, size = "sm" }: PlayerMapProps) => {
+    const styles = playerMap({ size });
+
+    return (
+        <div className={styles.root}>
+            <PlayerAvatar playerId={playerId} playerName={playerName} size={size} />
+            <span className={styles.name}>{playerName}</span>
+        </div>
+    );
+};
+
+export { PlayerMap };
+export type { PlayerMapProps, PlayerMapSize };

--- a/packages/react/src/components/player-map/index.tsx
+++ b/packages/react/src/components/player-map/index.tsx
@@ -1,12 +1,19 @@
 "use client";
 import { playerMap } from "styled-system/recipes";
-import { PlayerAvatar, type PlayerAvatarSize } from "../player-avatar";
 
-// チップの大きさ。中の PlayerAvatar のサイズにそのまま対応させる
-type PlayerMapSize = PlayerAvatarSize;
+// チップの大きさ。外枠(白 + 薄緑リング)を含めたアバターの寸法に対応する
+type PlayerMapSize = "sm" | "md" | "lg";
+
+// size ごとの、mc-heads.net に要求するアバター画像の実ピクセルサイズ。
+// 外枠(白 2px + 薄緑 2px)を含めた寸法に合わせておけば、頭は十分な解像度で表示できる
+const AVATAR_PIXEL_SIZE: Record<PlayerMapSize, number> = {
+    sm: 28,
+    md: 40,
+    lg: 52,
+};
 
 interface PlayerMapProps {
-    /** プレイヤーの UUID。PlayerAvatar 経由でアバター画像の取得に使う */
+    /** プレイヤーの UUID。mc-heads.net からアバター画像を取得するのに使う */
     playerId: string;
     /** プレイヤー名。アバターの alt とチップに並べるラベルの両方に使う */
     playerName: string;
@@ -14,14 +21,23 @@ interface PlayerMapProps {
     size?: PlayerMapSize;
 }
 
-// 地図上に置くプレイヤーマーカー。PlayerAvatar(#48) の顔アイコンに名前を添えた、
-// 白フチ + 薄緑のチップ。地図のどんな背景に載せても浮いて見えるようにする
+// 地図上に置くプレイヤーマーカー。頭(アバター)を「白 2px + 薄緑 2px」の枠で囲み、
+// 名前を添えた白フチ + 薄緑のチップ。地図のどんな背景に載せても浮いて見えるようにする
 const PlayerMap = ({ playerId, playerName, size = "sm" }: PlayerMapProps) => {
     const styles = playerMap({ size });
+    const pixelSize = AVATAR_PIXEL_SIZE[size];
 
     return (
         <div className={styles.root}>
-            <PlayerAvatar playerId={playerId} playerName={playerName} size={size} />
+            <span className={styles.avatar}>
+                <img
+                    className={styles.avatarImage}
+                    src={`https://mc-heads.net/avatar/${playerId}/${pixelSize}`}
+                    alt={playerName}
+                    width={pixelSize}
+                    height={pixelSize}
+                />
+            </span>
             <span className={styles.name}>{playerName}</span>
         </div>
     );

--- a/packages/react/src/components/player-map/index.tsx
+++ b/packages/react/src/components/player-map/index.tsx
@@ -1,15 +1,15 @@
 "use client";
 import { playerMap } from "styled-system/recipes";
 
-// チップの大きさ。外枠(白 + 薄緑リング)を含めたアバターの寸法に対応する
-type PlayerMapSize = "sm" | "md" | "lg";
+// MoriPath 版に合わせた 3 サイズ(md がデフォルト)
+type PlayerMapSize = "md" | "lg" | "xl";
 
-// size ごとの、mc-heads.net に要求するアバター画像の実ピクセルサイズ。
-// 外枠(白 2px + 薄緑 2px)を含めた寸法に合わせておけば、頭は十分な解像度で表示できる
+// size ごとに mc-heads.net へ要求するアバター画像の実ピクセルサイズ。
+// レシピの avatar 幅・高さと一致させる
 const AVATAR_PIXEL_SIZE: Record<PlayerMapSize, number> = {
-    sm: 28,
-    md: 40,
-    lg: 52,
+    md: 32,
+    lg: 36,
+    xl: 48,
 };
 
 interface PlayerMapProps {
@@ -21,23 +21,21 @@ interface PlayerMapProps {
     size?: PlayerMapSize;
 }
 
-// 地図上に置くプレイヤーマーカー。頭(アバター)を「白 2px + 薄緑 2px」の枠で囲み、
-// 名前を添えた白フチ + 薄緑のチップ。地図のどんな背景に載せても浮いて見えるようにする
-const PlayerMap = ({ playerId, playerName, size = "sm" }: PlayerMapProps) => {
+// 地図上に置くプレイヤーマーカー。アバター画像に名前を添えた、白フチ + 淡い下地のチップ。
+// MoriPath の player-map をそのまま移植している
+const PlayerMap = ({ playerId, playerName, size = "md" }: PlayerMapProps) => {
     const styles = playerMap({ size });
     const pixelSize = AVATAR_PIXEL_SIZE[size];
 
     return (
         <div className={styles.root}>
-            <span className={styles.avatar}>
-                <img
-                    className={styles.avatarImage}
-                    src={`https://mc-heads.net/avatar/${playerId}/${pixelSize}`}
-                    alt={playerName}
-                    width={pixelSize}
-                    height={pixelSize}
-                />
-            </span>
+            <img
+                className={styles.avatar}
+                src={`https://mc-heads.net/avatar/${playerId}/${pixelSize}`}
+                alt={playerName}
+                width={pixelSize}
+                height={pixelSize}
+            />
             <span className={styles.name}>{playerName}</span>
         </div>
     );

--- a/packages/react/src/preset/token/recipes/index.ts
+++ b/packages/react/src/preset/token/recipes/index.ts
@@ -4,6 +4,7 @@ import { button } from "./button";
 import { list } from "./list";
 import { minecraftItem } from "./minecraft-item";
 import { playerAvatar } from "./player-avatar";
+import { playerMap } from "./player-map";
 import { playerPhraseCard } from "./player-phrase-card";
 import { skinViewer } from "./skin-viewer";
 
@@ -17,6 +18,7 @@ export const recipes = {
 // 複数スロットを持つレシピ
 export const slotRecipes = {
     playerAvatar,
+    playerMap,
     playerPhraseCard,
     list,
     accordion,

--- a/packages/react/src/preset/token/recipes/player-map.ts
+++ b/packages/react/src/preset/token/recipes/player-map.ts
@@ -1,94 +1,67 @@
 import { defineSlotRecipe } from "@pandacss/dev";
 
+// MoriPath の player-map コンポーネントをそのまま移植したもの。
+// Chakra の CSS 変数を Chlorophyll(Panda)のトークンに置き換えているだけで、
+// 構造・数値・バリアントは MoriPath 版に一致させている
 export const playerMap = defineSlotRecipe({
     className: "player-map",
     jsx: ["PlayerMap"],
     description: "The player map marker chip component",
     // プリセット側でスロットの CSS を生成し、パッケージ利用者がソースを
     // スキャンしなくてもスタイルが当たるようにする
-    slots: ["root", "avatar", "avatarImage", "name"],
+    slots: ["root", "avatar", "name"],
     base: {
         root: {
             display: "inline-flex",
             alignItems: "center",
+            borderRadius: "lg",
             boxSizing: "border-box",
-            // 名前が長くてもチップ自体は中身に合わせて縮む
+            bg: "colorPalette.bg.subtle",
+            borderWidth: "2px",
+            borderStyle: "solid",
+            borderColor: "white",
             flexShrink: 0,
             minWidth: 0,
             overflow: "hidden",
-            borderRadius: "lg",
-            // 地図上のどんな背景に載せても浮いて見えるよう、白フチで縁取る
-            borderWidth: "2px",
-            borderStyle: "solid",
-            borderColor: "white",
-            // 薄い緑の下地(leaf/50 相当)
-            bg: "colorPalette.surface",
         },
         avatar: {
-            boxSizing: "border-box",
             flexShrink: 0,
-            display: "flex",
-            overflow: "hidden",
-            // 外側の白枠 2px。box-sizing: border-box なので枠は外形(例: 32px)に含まれ、
-            // 内側の頭は「外形 - 4px」(例: 28px)ちょうどになる
-            borderWidth: "2px",
-            borderStyle: "solid",
-            borderColor: "white",
-            // チップ(角丸 8px)と同心になるよう、一段小さい 4px にする
-            borderRadius: "sm",
-        },
-        avatarImage: {
-            width: "full",
-            height: "full",
+            borderRadius: "md",
             objectFit: "cover",
-            // ドット絵をぼかさずクッキリ表示する
-            imageRendering: "pixelated",
-            // 白枠と頭の間に薄緑 2px のリングを重ねる。outline を内側(offset -2px)に引くことで
-            // レイアウトを増やさずに「白 2px → 薄緑 2px → 頭」の重なりを作る
-            outlineWidth: "2px",
-            outlineStyle: "solid",
-            outlineColor: "colorPalette.surface",
-            outlineOffset: "-2px",
-            // 頭は枠より一段小さい角丸にして角をそろえる
-            borderRadius: "xs",
+            borderWidth: "0.5px",
+            borderStyle: "solid",
+            borderColor: "border/40",
         },
         name: {
+            fontVariationSettings: "'wght' 600",
+            fontWeight: "600",
+            fontSize: "sm",
+            color: "colorPalette.fg",
             flexShrink: 0,
-            whiteSpace: "nowrap",
             lineHeight: "1",
-            fontWeight: "bold",
-            fontVariationSettings: "'wght' 700",
-            // 中間トーンの緑(leaf/600 相当)で名前を読ませる
-            color: "colorPalette.solid",
         },
     },
     variants: {
         size: {
-            sm: {
-                // gap 6px / 左 4px・右 10px / 上下 2px
-                root: { gap: "1.5", pl: "1", pr: "2.5", py: "0.5" },
-                // アバター全体 32px(白 2 + 薄緑 2 + 頭 28)。チップ高さは 32 + 上下 4 = 36px
-                avatar: { width: "[32px]", height: "[32px]" },
-                name: { fontSize: "sm" },
-            },
-            md: {
-                // gap 8px / 左 6px・右 12px / 上下 4px
-                root: { gap: "2", pl: "1.5", pr: "3", py: "1" },
-                // アバター全体 44px(頭 40)
-                avatar: { width: "[44px]", height: "[44px]" },
-                name: { fontSize: "md" },
+            xl: {
+                root: { gap: "2", height: "[52px]", pr: "3" },
+                avatar: { width: "[48px]", height: "[48px]" },
+                name: { fontSize: "xl" },
             },
             lg: {
-                // gap 10px / 左 8px・右 14px / 上下 6px
-                root: { gap: "2.5", pl: "2", pr: "3.5", py: "1.5" },
-                // アバター全体 56px(頭 52)
-                avatar: { width: "[56px]", height: "[56px]" },
-                name: { fontSize: "lg" },
+                root: { gap: "1.5", height: "[36px]", pr: "2" },
+                avatar: { width: "[36px]", height: "[36px]" },
+                name: { fontSize: "sm", fontWeight: "bold" },
+            },
+            md: {
+                root: { gap: "1.5", height: "[36px]", pr: "2" },
+                avatar: { width: "[32px]", height: "[32px]" },
+                name: { fontSize: "sm" },
             },
         },
     },
     defaultVariants: {
-        size: "sm",
+        size: "md",
     },
     // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
     staticCss: ["*"],

--- a/packages/react/src/preset/token/recipes/player-map.ts
+++ b/packages/react/src/preset/token/recipes/player-map.ts
@@ -1,0 +1,62 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const playerMap = defineSlotRecipe({
+    className: "player-map",
+    jsx: ["PlayerMap"],
+    description: "The player map marker chip component",
+    // プリセット側でスロットの CSS を生成し、パッケージ利用者がソースを
+    // スキャンしなくてもスタイルが当たるようにする
+    slots: ["root", "name"],
+    base: {
+        root: {
+            display: "inline-flex",
+            alignItems: "center",
+            boxSizing: "border-box",
+            // 名前が長くてもチップ自体は中身に合わせて縮む
+            flexShrink: 0,
+            minWidth: 0,
+            overflow: "hidden",
+            borderRadius: "lg",
+            // 地図上のどんな背景に載せても浮いて見えるよう、白フチで縁取る
+            borderWidth: "2px",
+            borderStyle: "solid",
+            borderColor: "white",
+            // 薄い緑の下地(leaf/50 相当)
+            bg: "colorPalette.surface",
+        },
+        name: {
+            flexShrink: 0,
+            whiteSpace: "nowrap",
+            lineHeight: "1",
+            fontWeight: "bold",
+            fontVariationSettings: "'wght' 700",
+            // 中間トーンの緑(leaf/600 相当)で名前を読ませる
+            color: "colorPalette.solid",
+        },
+    },
+    variants: {
+        // size は PlayerAvatar のサイズとそのまま対応させる
+        size: {
+            sm: {
+                // gap 6px / 左 4px・右 10px / 上下 4px
+                root: { gap: "1.5", pl: "1", pr: "2.5", py: "1" },
+                name: { fontSize: "sm" },
+            },
+            md: {
+                // gap 8px / 左 6px・右 12px / 上下 6px
+                root: { gap: "2", pl: "1.5", pr: "3", py: "1.5" },
+                name: { fontSize: "lg" },
+            },
+            lg: {
+                // gap 10px / 左 8px・右 14px / 上下 8px
+                root: { gap: "2.5", pl: "2", pr: "3.5", py: "2" },
+                name: { fontSize: "xl" },
+            },
+        },
+    },
+    defaultVariants: {
+        size: "sm",
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/player-map.ts
+++ b/packages/react/src/preset/token/recipes/player-map.ts
@@ -6,7 +6,7 @@ export const playerMap = defineSlotRecipe({
     description: "The player map marker chip component",
     // プリセット側でスロットの CSS を生成し、パッケージ利用者がソースを
     // スキャンしなくてもスタイルが当たるようにする
-    slots: ["root", "name"],
+    slots: ["root", "avatar", "avatarImage", "name"],
     base: {
         root: {
             display: "inline-flex",
@@ -24,6 +24,29 @@ export const playerMap = defineSlotRecipe({
             // 薄い緑の下地(leaf/50 相当)
             bg: "colorPalette.surface",
         },
+        avatar: {
+            boxSizing: "border-box",
+            flexShrink: 0,
+            display: "flex",
+            // 外から順に「白 2px の枠 → 薄緑 2px のリング → 内側の頭」を作る。
+            // 枠は白、リングは padding に下地の薄緑を覗かせて表現する
+            borderWidth: "2px",
+            borderStyle: "solid",
+            borderColor: "white",
+            padding: "2px",
+            bg: "colorPalette.surface",
+            // チップ(角丸 8px)と同心になるよう、左パディング 4px 分だけ小さい 4px にする
+            borderRadius: "sm",
+        },
+        avatarImage: {
+            width: "full",
+            height: "full",
+            objectFit: "cover",
+            // ドット絵をぼかさずクッキリ表示する
+            imageRendering: "pixelated",
+            // 頭は枠より一段小さい角丸にして角をそろえる
+            borderRadius: "xs",
+        },
         name: {
             flexShrink: 0,
             whiteSpace: "nowrap",
@@ -35,22 +58,27 @@ export const playerMap = defineSlotRecipe({
         },
     },
     variants: {
-        // size は PlayerAvatar のサイズとそのまま対応させる
         size: {
             sm: {
                 // gap 6px / 左 4px・右 10px / 上下 4px
                 root: { gap: "1.5", pl: "1", pr: "2.5", py: "1" },
+                // 外枠 28px(白 2 + 薄緑 2 + 頭 20)。チップ高さは 28 + 上下 8 = 36px
+                avatar: { width: "[28px]", height: "[28px]" },
                 name: { fontSize: "sm" },
             },
             md: {
                 // gap 8px / 左 6px・右 12px / 上下 6px
                 root: { gap: "2", pl: "1.5", pr: "3", py: "1.5" },
-                name: { fontSize: "lg" },
+                // 外枠 40px(頭 32)
+                avatar: { width: "[40px]", height: "[40px]" },
+                name: { fontSize: "md" },
             },
             lg: {
                 // gap 10px / 左 8px・右 14px / 上下 8px
                 root: { gap: "2.5", pl: "2", pr: "3.5", py: "2" },
-                name: { fontSize: "xl" },
+                // 外枠 52px(頭 44)
+                avatar: { width: "[52px]", height: "[52px]" },
+                name: { fontSize: "lg" },
             },
         },
     },

--- a/packages/react/src/preset/token/recipes/player-map.ts
+++ b/packages/react/src/preset/token/recipes/player-map.ts
@@ -28,14 +28,13 @@ export const playerMap = defineSlotRecipe({
             boxSizing: "border-box",
             flexShrink: 0,
             display: "flex",
-            // 外から順に「白 2px の枠 → 薄緑 2px のリング → 内側の頭」を作る。
-            // 枠は白、リングは padding に下地の薄緑を覗かせて表現する
+            overflow: "hidden",
+            // 外側の白枠 2px。box-sizing: border-box なので枠は外形(例: 32px)に含まれ、
+            // 内側の頭は「外形 - 4px」(例: 28px)ちょうどになる
             borderWidth: "2px",
             borderStyle: "solid",
             borderColor: "white",
-            padding: "2px",
-            bg: "colorPalette.surface",
-            // チップ(角丸 8px)と同心になるよう、左パディング 4px 分だけ小さい 4px にする
+            // チップ(角丸 8px)と同心になるよう、一段小さい 4px にする
             borderRadius: "sm",
         },
         avatarImage: {
@@ -44,6 +43,12 @@ export const playerMap = defineSlotRecipe({
             objectFit: "cover",
             // ドット絵をぼかさずクッキリ表示する
             imageRendering: "pixelated",
+            // 白枠と頭の間に薄緑 2px のリングを重ねる。outline を内側(offset -2px)に引くことで
+            // レイアウトを増やさずに「白 2px → 薄緑 2px → 頭」の重なりを作る
+            outlineWidth: "2px",
+            outlineStyle: "solid",
+            outlineColor: "colorPalette.surface",
+            outlineOffset: "-2px",
             // 頭は枠より一段小さい角丸にして角をそろえる
             borderRadius: "xs",
         },
@@ -60,24 +65,24 @@ export const playerMap = defineSlotRecipe({
     variants: {
         size: {
             sm: {
-                // gap 6px / 左 4px・右 10px / 上下 4px
-                root: { gap: "1.5", pl: "1", pr: "2.5", py: "1" },
-                // 外枠 28px(白 2 + 薄緑 2 + 頭 20)。チップ高さは 28 + 上下 8 = 36px
-                avatar: { width: "[28px]", height: "[28px]" },
+                // gap 6px / 左 4px・右 10px / 上下 2px
+                root: { gap: "1.5", pl: "1", pr: "2.5", py: "0.5" },
+                // アバター全体 32px(白 2 + 薄緑 2 + 頭 28)。チップ高さは 32 + 上下 4 = 36px
+                avatar: { width: "[32px]", height: "[32px]" },
                 name: { fontSize: "sm" },
             },
             md: {
-                // gap 8px / 左 6px・右 12px / 上下 6px
-                root: { gap: "2", pl: "1.5", pr: "3", py: "1.5" },
-                // 外枠 40px(頭 32)
-                avatar: { width: "[40px]", height: "[40px]" },
+                // gap 8px / 左 6px・右 12px / 上下 4px
+                root: { gap: "2", pl: "1.5", pr: "3", py: "1" },
+                // アバター全体 44px(頭 40)
+                avatar: { width: "[44px]", height: "[44px]" },
                 name: { fontSize: "md" },
             },
             lg: {
-                // gap 10px / 左 8px・右 14px / 上下 8px
-                root: { gap: "2.5", pl: "2", pr: "3.5", py: "2" },
-                // 外枠 52px(頭 44)
-                avatar: { width: "[52px]", height: "[52px]" },
+                // gap 10px / 左 8px・右 14px / 上下 6px
+                root: { gap: "2.5", pl: "2", pr: "3.5", py: "1.5" },
+                // アバター全体 56px(頭 52)
+                avatar: { width: "[56px]", height: "[56px]" },
                 name: { fontSize: "lg" },
             },
         },

--- a/storybook/stories/player-map/index.stories.tsx
+++ b/storybook/stories/player-map/index.stories.tsx
@@ -13,13 +13,13 @@ const meta: Meta<typeof PlayerMap> = {
         playerName: { control: "text" },
         size: {
             control: "select",
-            options: ["sm", "md", "lg"],
+            options: ["md", "lg", "xl"],
         },
     },
     args: {
         playerId: "389b1a68-f647-4dd0-a421-61b6c22fdebe",
         playerName: "Chocolatt",
-        size: "sm",
+        size: "md",
     },
 };
 
@@ -32,9 +32,9 @@ export const Sizes: Story = {
     parameters: { layout: "padded" },
     render: (args) => (
         <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
-            <PlayerMap {...args} size="sm" />
             <PlayerMap {...args} size="md" />
             <PlayerMap {...args} size="lg" />
+            <PlayerMap {...args} size="xl" />
         </div>
     ),
 };

--- a/storybook/stories/player-map/index.stories.tsx
+++ b/storybook/stories/player-map/index.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PlayerMap } from "../../../packages/react";
+
+const meta: Meta<typeof PlayerMap> = {
+    title: "MINECRAFT/PlayerMap",
+    component: PlayerMap,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        playerId: { control: "text" },
+        playerName: { control: "text" },
+        size: {
+            control: "select",
+            options: ["sm", "md", "lg"],
+        },
+    },
+    args: {
+        playerId: "389b1a68-f647-4dd0-a421-61b6c22fdebe",
+        playerName: "Chocolatt",
+        size: "sm",
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlayerMap>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+    parameters: { layout: "padded" },
+    render: (args) => (
+        <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
+            <PlayerMap {...args} size="sm" />
+            <PlayerMap {...args} size="md" />
+            <PlayerMap {...args} size="lg" />
+        </div>
+    ),
+};


### PR DESCRIPTION
## 概要

Figma の [usermap (159-797)](https://www.figma.com/design/bLFItyZuAZLUHnceC1EBJI/app.morino.party?node-id=159-797&m=dev) デザインを、[MoriPath の `player-map`](https://github.com/morinoparty/MoriPath/blob/main/app/components/player-map/index.tsx) 実装を参考に、Chlorophyll 流（Panda CSS + 既存 `PlayerAvatar` 再利用）で `PlayerMap` コンポーネントとして実装しました。

地図上に置くプレイヤーマーカー用の、白フチ + 薄緑のチップです。

## 変更内容

- `packages/react/src/preset/token/recipes/player-map.ts` — slot recipe（`root` / `name`、size `sm` / `md` / `lg`）を追加
- `packages/react/src/components/player-map/index.tsx` — `PlayerAvatar` に委譲し名前ラベルを添えるコンポーネント本体を追加
- `storybook/stories/player-map/index.stories.tsx` — Storybook ストーリー（Default / Sizes）を追加
- レシピ・コンポーネントの export を登録

## デザイン → トークンのマッピング

| デザイン | トークン |
|---|---|
| 背景 `leaf/50` | `colorPalette.surface`（mori.3） |
| 名前文字 `leaf/600 #488669` | `colorPalette.solid`（mori.9） |
| 角丸 8px | `radii.lg` |
| 白フチ 2px | `borderColor: white` |

`size` は `PlayerAvatar` の `sm` / `md` / `lg` にそのまま連動（デフォルトはデザイン準拠の `sm`）。

## 検証

- `panda codegen`（react / storybook 両方）で `playerMap` レシピ生成を確認
- `pnpm run check`（Biome）通過 / `tsc --noEmit` 通過
- Storybook を Playwright で撮影し、3 サイズとも Figma 通りに表示されることを確認

## 補足

既存の `PlayerAvatar`（sm=32px・角丸8px・枠線なし）に委譲しているため、デザインのアバター（28px・角丸4px・薄枠線）とはその点のみ厳密なピクセル一致ではありません。デザインシステム統一を優先した結果です。