### PR TITLE
✨ Add interactive prop to SkinViewer and harden VRT capture for WebGL

### DIFF
--- a/packages/react/src/components/skin-viewer/index.tsx
+++ b/packages/react/src/components/skin-viewer/index.tsx
@@ -39,6 +39,11 @@ interface SkinViewerProps extends Omit<HTMLArkProps<"canvas">, "width" | "height
     autoRotate?: boolean;
     /** 再生するアニメーション。"none" ならポーズしたまま静止表示する */
     animation?: SkinViewerAnimation;
+    /**
+     * マウス操作(回転・ズーム・パン)を受け付けるか。false にすると操作を全てロックした
+     * 表示専用モードになる。autoRotate による自動回転は操作ロックとは独立して機能する
+     */
+    interactive?: boolean;
 }
 
 const DEFAULT_WIDTH = 300;
@@ -59,11 +64,12 @@ const SkinViewer = ({
     height = DEFAULT_HEIGHT,
     autoRotate = true,
     animation = "idle",
+    interactive = true,
     ...props
 }: SkinViewerProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const viewerRef = useRef<SkinViewer3D | null>(null);
-    const styles = skinViewerRecipe();
+    const styles = skinViewerRecipe({ interactive });
 
     // マウント時に 1 度だけ SkinViewer3D を生成し、アンマウント時に必ず dispose する。
     // WebGL コンテキストはリークしやすく、StrictMode の二重実行下でも安全なように
@@ -101,6 +107,16 @@ const SkinViewer = ({
         }
         viewer.autoRotate = autoRotate;
     }, [autoRotate]);
+
+    // マウス操作の受け付けを OrbitControls の enabled で一括制御する。
+    // false で回転・ズーム・パンを全てロックし、表示専用にする
+    useEffect(() => {
+        const viewer = viewerRef.current;
+        if (!viewer) {
+            return;
+        }
+        viewer.controls.enabled = interactive;
+    }, [interactive]);
 
     useEffect(() => {
         const viewer = viewerRef.current;

--- a/packages/react/src/preset/token/recipes/skin-viewer.ts
+++ b/packages/react/src/preset/token/recipes/skin-viewer.ts
@@ -4,9 +4,29 @@ export const skinViewer = defineRecipe({
     className: "skin-viewer",
     jsx: ["SkinViewer"],
     description: "The skin viewer component",
+    // interactive は実行時に prop で動的指定されるため、両方の CSS を常に生成する
+    staticCss: ["*"],
     base: {
         display: "block",
         borderRadius: "lg",
         bg: "bg.subtle",
+    },
+    variants: {
+        // マウス操作(回転・ズーム・パン)を受け付けるかどうか。
+        // false の場合は操作を全てロックした表示専用モードになる(振る舞いは component 側で制御)。
+        // ここではカーソル形状で操作可否を視覚的に示す
+        interactive: {
+            true: {
+                // ドラッグで動かせることを示す掴めるカーソル
+                cursor: "grab",
+            },
+            false: {
+                // 操作できないので通常カーソルのまま
+                cursor: "default",
+            },
+        },
+    },
+    defaultVariants: {
+        interactive: true,
     },
 });

--- a/storybook/scripts/vrt-capture.mjs
+++ b/storybook/scripts/vrt-capture.mjs
@@ -7,6 +7,7 @@ import { spawn } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { deflateSync } from "node:zlib";
 
 const require = createRequire(import.meta.url);
 const puppeteer = require("puppeteer");
@@ -29,10 +30,84 @@ const sanitize = (s) => s.replace(/[/\\?%*:|"<>]/g, "-").trim();
 // VRT を外部サービスに依存させないため、アバター画像リクエストは決定的な
 // ローカル画像で応答する。URL(playerId を含む)から色を決めて見分けられるようにする。
 const AVATAR_HOST = "mc-heads.net";
+// PlayerAvatar は <img> でアバターを表示するだけなので、軽い SVG で代替できる
 const deterministicAvatar = (url) => {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" fill="hsl(${hueFromUrl(url)} 45% 55%)"/></svg>`;
+};
+
+// URL(playerId を含む)から決定的に色相を導出し、プレイヤーごとに見分けられるようにする
+const hueFromUrl = (url) => {
     let hue = 0;
     for (const ch of url) hue = (hue * 31 + ch.charCodeAt(0)) % 360;
-    return `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><rect width="48" height="48" fill="hsl(${hue} 45% 55%)"/></svg>`;
+    return hue;
+};
+
+// SkinViewer(skinview3d)は SVG ではなく 64x64 の PNG スキンテクスチャを要求し、
+// three.js の TextureLoader は crossOrigin 付きで読み込むため、後述の応答には CORS
+// ヘッダも必須になる。ここでは全面を単色で塗った最小の正当な PNG を生成する
+// (playerId ごとに色相を変えて見分けられるようにする)。
+const CRC_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        table[n] = c >>> 0;
+    }
+    return table;
+})();
+const crc32 = (buf) => {
+    let c = 0xffffffff;
+    for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+};
+// PNG チャンク(length + type + data + CRC32)を組み立てる
+const pngChunk = (type, data) => {
+    const typeBuf = Buffer.from(type, "ascii");
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length, 0);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+    return Buffer.concat([len, typeBuf, data, crc]);
+};
+const hslToRgb = (h, s, l) => {
+    const hue2rgb = (p, q, t) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    return [hue2rgb(p, q, h + 1 / 3), hue2rgb(p, q, h), hue2rgb(p, q, h - 1 / 3)].map((v) => Math.round(v * 255));
+};
+const deterministicSkin = (url) => {
+    const size = 64;
+    const [r, g, b] = hslToRgb(hueFromUrl(url) / 360, 0.5, 0.55);
+    // 各行の先頭にフィルタバイト 0(なし)を付けた生 RGBA スキャンライン
+    const raw = Buffer.alloc((size * 4 + 1) * size);
+    let p = 0;
+    for (let y = 0; y < size; y++) {
+        raw[p++] = 0;
+        for (let x = 0; x < size; x++) {
+            raw[p++] = r;
+            raw[p++] = g;
+            raw[p++] = b;
+            raw[p++] = 255;
+        }
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(size, 0); // width
+    ihdr.writeUInt32BE(size, 4); // height
+    ihdr[8] = 8; // bit depth
+    ihdr[9] = 6; // color type: RGBA
+    return Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        pngChunk("IHDR", ihdr),
+        pngChunk("IDAT", deflateSync(raw)),
+        pngChunk("IEND", Buffer.alloc(0)),
+    ]);
 };
 
 // 既存のサーバーを使う場合は VRT_STORYBOOK_URL を指定(ローカル検証用)。
@@ -73,6 +148,11 @@ async function fetchStories(baseUrl) {
     return Object.values(json.entries).filter((e) => e.type === "story");
 }
 
+// WebGL を使うストーリー(react-three-fiber や skinview3d)は、多数のストーリーを
+// 連続撮影した後だと初期化が大きく遅れることがある(ソフトウェアレンダリング環境での
+// リソース競合と見られる)。通常は 1〜2 秒で終わるが、余裕を持って長めに待つ
+const NAVIGATION_TIMEOUT_MS = 45000;
+
 async function captureStory(page, baseUrl, story, viewport) {
     await page.setViewport({
         width: viewport.width,
@@ -81,7 +161,7 @@ async function captureStory(page, baseUrl, story, viewport) {
     });
     await page.goto(`${baseUrl}/iframe.html?id=${story.id}&viewMode=story`, {
         waitUntil: "networkidle0",
-        timeout: 20000,
+        timeout: NAVIGATION_TIMEOUT_MS,
     });
     await page.addStyleTag({ content: DISABLE_ANIMATION_CSS });
     // フォントと画像の読み込みを待つ
@@ -109,28 +189,75 @@ async function captureStory(page, baseUrl, story, viewport) {
     return file;
 }
 
+// ページを使い回すより状態を持ち越さない方が安全なため、ストーリーごとに使い捨てのページで撮影する
+async function capturePage(browser, baseUrl, story, viewport) {
+    const page = await browser.newPage();
+    try {
+        // skinview3d は performance.now() を時間源(THREE.Clock)として autoRotate や
+        // アニメーションを進める。撮影タイミングでポーズが変わり VRT が毎回差分になるのを防ぐため、
+        // 時間源を定数に固定して delta を常に 0 にする(描画自体は行われ、ポーズだけ凍結される)。
+        await page.evaluateOnNewDocument(() => {
+            const FIXED = 1000;
+            performance.now = () => FIXED;
+        });
+        await page.setRequestInterception(true);
+        // mc-heads.net へのアクセスを横取りして決定的な画像を返す。three.js の TextureLoader は
+        // crossOrigin 付きで読むため、いずれの応答にも CORS ヘッダを付ける。
+        page.on("request", (req) => {
+            const url = req.url();
+            if (!url.includes(AVATAR_HOST)) {
+                req.continue();
+                return;
+            }
+            const headers = { "Access-Control-Allow-Origin": "*" };
+            // /skin/ は SkinViewer 用のスキンテクスチャ。PNG を返す。それ以外(/avatar/)は
+            // PlayerAvatar 用の <img> なので軽い SVG で足りる。
+            if (url.includes("/skin/")) {
+                req.respond({ status: 200, contentType: "image/png", headers, body: deterministicSkin(url) });
+            } else {
+                req.respond({ status: 200, contentType: "image/svg+xml", headers, body: deterministicAvatar(url) });
+            }
+        });
+        return await captureStory(page, baseUrl, story, viewport);
+    } finally {
+        await page.close();
+    }
+}
+
+// 長時間の連続撮影ではまれにナビゲーションが遅延/失敗することがあるため、
+// 1 回失敗しても新しいページでもう一度だけ試す
+async function capturePageWithRetry(browser, baseUrl, story, viewport) {
+    try {
+        return await capturePage(browser, baseUrl, story, viewport);
+    } catch (error) {
+        console.log(`retrying ${story.id} (${viewport.label}) after error: ${error.message}`);
+        return await capturePage(browser, baseUrl, story, viewport);
+    }
+}
+
 async function main() {
     const server = await startServer();
     const browser = await puppeteer.launch({
-        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
+        args: [
+            "--no-sandbox",
+            "--disable-setuid-sandbox",
+            "--disable-dev-shm-usage",
+            // WebGL(react-three-fiber / skinview3d)を使うストーリーが多いと、
+            // 既定の GPU 解決だと不安定になりやすい。SwiftShader に固定して安定させる。
+            // Chrome 150+ ではソフトウェア WebGL の自動フォールバックが無効化されたため、
+            // --enable-unsafe-swiftshader で明示的に許可する必要がある(信頼済みコンテンツのみ)
+            "--use-gl=angle",
+            "--use-angle=swiftshader",
+            "--enable-unsafe-swiftshader",
+            "--disable-gpu-sandbox",
+        ],
     });
     try {
         const stories = await fetchStories(server.baseUrl);
-        const page = await browser.newPage();
-
-        // アバター(mc-heads.net)へのアクセスを横取りして決定的な画像を返す
-        await page.setRequestInterception(true);
-        page.on("request", (req) => {
-            if (req.url().includes(AVATAR_HOST)) {
-                req.respond({ status: 200, contentType: "image/svg+xml", body: deterministicAvatar(req.url()) });
-            } else {
-                req.continue();
-            }
-        });
         let count = 0;
         for (const viewport of VIEWPORTS) {
             for (const story of stories) {
-                const file = await captureStory(page, server.baseUrl, story, viewport);
+                const file = await capturePageWithRetry(browser, server.baseUrl, story, viewport);
                 count += 1;
                 console.log(`captured: ${file}`);
             }

--- a/storybook/stories/skin-viewer/index.stories.tsx
+++ b/storybook/stories/skin-viewer/index.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof SkinViewer> = {
             control: "select",
             options: ["idle", "walking", "running", "wave", "none"],
         },
+        interactive: { control: "boolean" },
     },
     args: {
         playerId: "389b1a68-f647-4dd0-a421-61b6c22fdebe",
@@ -25,6 +26,7 @@ const meta: Meta<typeof SkinViewer> = {
         height: 400,
         autoRotate: true,
         animation: "idle",
+        interactive: true,
     },
 };
 
@@ -45,5 +47,15 @@ export const CustomSkinUrl: Story = {
     args: {
         playerId: undefined,
         skinUrl: "https://mc-heads.net/skin/f8b761ec-4a54-48eb-a040-c5604042bcc9",
+    },
+};
+
+// マウス操作(回転・ズーム・パン)を全てロックした表示専用モード。
+// autoRotate による自動回転は操作ロックとは独立して機能する
+export const NonInteractive: Story = {
+    args: {
+        interactive: false,
+        autoRotate: false,
+        animation: "none",
     },
 };


### PR DESCRIPTION
## 概要

`SkinViewer` にマウス操作の可否を切り替える `interactive` prop を追加し、あわせて VRT キャプチャスクリプトを WebGL(skinview3d / react-three-fiber)ストーリーに対応できるよう強化しました。

## 変更内容

### `SkinViewer` に `interactive` prop を追加
- `interactive`(既定 `true`)で回転・ズーム・パンの受け付けを一括制御。`false` にすると `OrbitControls.enabled = false` で操作を全てロックした表示専用モードになります。
- `autoRotate` による自動回転は操作ロックとは独立して機能します。
- recipe に `interactive` variant を追加し、カーソル形状(`grab` / `default`)で操作可否を視覚的に示します。
- Storybook に `NonInteractive` ストーリーを追加。

### VRT キャプチャ (`storybook/scripts/vrt-capture.mjs`) の強化
- SkinViewer 用に、決定的な 64x64 PNG スキンテクスチャを生成して差し込む処理を追加(three.js の `TextureLoader` は CORS 付きで読むため、応答に CORS ヘッダも付与)。`/skin/` は PNG、`/avatar/` は従来通り軽量 SVG で応答。
- `performance.now()` を定数に固定し、skinview3d のアニメーション/自動回転のポーズを凍結して VRT を決定的にする。
- SwiftShader(`--use-angle=swiftshader` ほか)へ固定し、ソフトウェア WebGL 環境で安定描画。Chrome 150+ 向けに `--enable-unsafe-swiftshader` も付与。
- ストーリーごとに使い捨てページで撮影 + 1 回リトライ + ナビゲーションタイムアウトを延長し、連続撮影時の初期化遅延に対処。

## 検証

- `pnpm --filter @morinoparty/chlorophyll-react exec tsc --noEmit` 通過
- Biome(対象ファイル)通過
- `panda codegen` で `skin-viewer` recipe に `interactive` variant が生成されることを確認

## 補足

生成ファイル(`docs/app/routeTree.gen.ts`)は Biome による再整形ノイズが混ざらないよう本 PR には含めていません。