### PR TITLE
💄 Refine Badge appearance & fix yellow dark-mode contrast

### DIFF
--- a/packages/react/src/components/badge/index.tsx
+++ b/packages/react/src/components/badge/index.tsx
@@ -42,8 +42,8 @@ const Badge = ({ className, variant, size, status, dot, children, ...props }: Ba
 // ドット単体には意味がないため、装飾として扱い aria-hidden にする
 const dotStyle = css({
     display: "inline-block",
-    width: "0.5em",
-    height: "0.5em",
+    width: "0.55em",
+    height: "0.55em",
     borderRadius: "full",
     bg: "colorPalette.solid",
     flexShrink: 0,

--- a/packages/react/src/preset/token/recipes/badge.ts
+++ b/packages/react/src/preset/token/recipes/badge.ts
@@ -12,9 +12,12 @@ export const badge = defineRecipe({
         alignItems: "center",
         justifyContent: "center",
         gap: "1",
-        // 角丸でピル状に見せる
-        borderRadius: "md",
-        fontWeight: "medium",
+        // 完全な角丸でピル状にし、ステータス/ラベルのタグとして読ませる
+        borderRadius: "full",
+        // button 一家と揃えたセミボールド。小さな文字でもくっきり読ませる
+        fontWeight: "semibold",
+        // 短いラベルを詰まって見せないよう、わずかに字間を開ける
+        letterSpacing: "wide",
         // 折り返さず 1 行で表示する
         whiteSpace: "nowrap",
         verticalAlign: "middle",
@@ -41,7 +44,8 @@ export const badge = defineRecipe({
             // 枠線のみ: 背景を持たせたくない場面向け
             outline: {
                 borderWidth: "1px",
-                borderColor: "colorPalette.solid",
+                // surface と同じ scale 7 に揃え、solid(scale 9)ほど枠線が主張しないようにする
+                borderColor: "colorPalette.7",
                 color: "colorPalette.fg",
             },
             // 淡い背景 + 枠線: subtle よりも輪郭を出しつつ outline より主張を抑えたい場面向け
@@ -53,17 +57,17 @@ export const badge = defineRecipe({
             },
         },
         size: {
-            // 12px 相当のコンパクトなタグ
+            // コンパクトなタグ
             sm: {
-                // 左右 6px / 上下 2px
-                px: "1.5",
+                // ピル状に見せるため左右をやや広めに。左右 8px / 上下 2px
+                px: "2",
                 py: "0.5",
                 fontSize: "xs",
             },
             // 標準サイズ
             md: {
-                // 左右 8px / 上下 4px
-                px: "2",
+                // ピル状に見せるため左右をやや広めに。左右 10px / 上下 4px
+                px: "2.5",
                 py: "1",
                 fontSize: "sm",
             },

--- a/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
@@ -191,9 +191,12 @@ export const yellow = defineSemanticTokens.colors({
                 value: "{colors.yellow.10}",
             },
         },
-        // Text on solid background (yellow needs dark text for contrast)
+        // Text on solid background (yellow needs dark text for contrast).
+        // yellow.solid(scale 9) は明るく、ライト/ダーク両テーマでほぼ同じ明るさのため、
+        // テーマ分岐する yellow.12 だとダーク時に淡いインクとなり文字が読めなくなる。
+        // どちらのテーマでも常に暗いインク(light ランプの 12)を重ねてコントラストを確保する。
         contrast: {
-            value: "{colors.yellow.12}",
+            value: "{colors.yellow.light.12}",
         },
     },
 });


### PR DESCRIPTION
## Summary
Badge の見た目を「小さいボタン」から「ステータス/ラベルのタグ」らしく磨き込み、あわせてダークモードで警告バッジの文字が読めなくなっていた token バグを修正しました。

### Badge の見た目改善 (`badge.ts` recipe / `badge/index.tsx`)
- 角丸 `md` → **`full`（ピル状）**
- ウェイト `medium` → **`semibold`** + **`letterSpacing: wide`**（button 一家と統一）
- `outline` の枠線 `colorPalette.solid`(scale 9) → **`colorPalette.7`**（surface と揃えて重い枠線を解消）
- 左右 padding 微調整（md 8→10px / sm 6→8px）でピルのバランス最適化
- status dot を 0.5em → 0.55em に微増

### ⚠️ デザインシステム全体への変更 (`yellow.ts`)
ダークモードで **solid の警告バッジの文字がほぼ不可視**でした（文字/背景の明度 0.94 vs 0.92）。原因は `yellow.contrast` がテーマ分岐する `{colors.yellow.12}`（ダークで淡いインク）だったこと。明るい `yellow.solid`(scale 9) は両テーマで明るいため、contrast を常に暗いインク **`{colors.yellow.light.12}`** に固定しました。
- 修正後：文字/背景 明度 **0.36 vs 0.92**（十分なコントラスト）
- **ライトモードは挙動不変**（`yellow.12` は元々 `yellow.light.12` に解決）
- これは公開 preset に含まれる token のため、**下流の全消費者に影響**します（現状このリポジトリで `colorPalette: yellow` を使うのは Badge の warning のみ）

## Verification
- Storybook `DATA DISPLAY/Badge` の Showcase を **ライト・ダーク両テーマ**でスクリーンショット確認
- ダークの警告バッジのコントラストを computed style で実測（0.94→0.36）
- `pnpm run check`（biome）green

## ⚠️ TODO before merge
- **VRT baseline の更新が必要**です。見た目を変更したため `storybook/__screenshots__/DATA DISPLAY/Badge` のスナップショットが不一致になり、`pr-check.yml` の `test:vrt` が失敗します。`pnpm test:vrt` でベースラインを再生成してください。