### PR TITLE
✨ Redesign top page with shadcn-style demo grid & unified button sizes

### DIFF
--- a/docs/app/components/color-palette-toggle/index.tsx
+++ b/docs/app/components/color-palette-toggle/index.tsx
@@ -33,16 +33,10 @@ export function ColorPaletteToggle({ className }: ColorPaletteToggleProps) {
             type="button"
             onClick={toggleTheme}
             className={cx(
+                // 見た目は呼び出し側の className に委ね、ここでは素のボタンにするだけに留める
                 css({
-                    bg: "red.1",
-                    border: "var(--mpc-borders-border-lg)",
+                    bg: "transparent",
                     cursor: "pointer",
-                    color: "colorPalette.fg.muted",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    transition: "colors",
-                    _hover: { color: "colorPalette.fg" },
                 }),
                 className,
             )}

--- a/docs/app/components/footer/index.tsx
+++ b/docs/app/components/footer/index.tsx
@@ -1,7 +1,17 @@
 import { Link } from "@tanstack/react-router";
 import { css } from "styled-system/css";
-import { flex, hstack, stack } from "styled-system/patterns";
+import { flex, hstack } from "styled-system/patterns";
 
+// フッターのテキストリンク共通スタイル
+const footerLink = css({
+    color: "colorPalette.fg.muted",
+    textDecoration: "none",
+    transition: "colors",
+    _hover: { color: "colorPalette.fg" },
+});
+
+// park-ui / shadcn のトップページに倣った 1 行だけの最小フッター。
+// 左にコピーライト、右に主要リンクを並べる
 export function Footer() {
     const currentYear = new Date().getFullYear();
 
@@ -9,94 +19,42 @@ export function Footer() {
         <footer
             className={css({
                 borderTop: "[1px solid]",
-                borderColor: "border",
-                bg: "bg",
+                borderColor: "border.subtle",
                 marginTop: "auto",
             })}
         >
             <div
                 className={flex({
-                    maxWidth: "7xl",
+                    maxWidth: "6xl",
                     marginX: "auto",
-                    paddingX: { base: "4", md: "6" },
-                    paddingY: "8",
-                    flexDirection: { base: "column", md: "row" },
+                    paddingX: { base: "5", md: "8" },
+                    paddingY: "6",
+                    flexDirection: { base: "column", sm: "row" },
                     justifyContent: "space-between",
-                    alignItems: { base: "start", md: "center" },
-                    gap: "6",
+                    alignItems: { base: "start", sm: "center" },
+                    gap: "4",
+                    fontSize: "sm",
                 })}
             >
-                {/* Left Section */}
-                <div className={stack({ gap: "2" })}>
-                    <div className={hstack({ gap: "2" })}>
-                        <img src="/chlorophyll.svg" alt="Chlorophyll" className={css({ width: "5", height: "5" })} />
-                        <span
-                            className={css({
-                                fontWeight: "semibold",
-                                color: "colorPalette.fg",
-                            })}
-                        >
-                            Chlorophyll
-                        </span>
-                    </div>
-                    <p className={css({ fontSize: "sm", color: "colorPalette.fg.muted" })}>
-                        A design system for Morinoparty projects.
-                    </p>
-                </div>
-
-                {/* Links */}
-                <div className={hstack({ gap: "6", fontSize: "sm" })}>
-                    <Link
-                        to="/docs/$"
-                        params={{ _splat: "getting-started/introduction" }}
-                        className={css({
-                            color: "colorPalette.fg.muted",
-                            textDecoration: "none",
-                            _hover: { color: "colorPalette.fg" },
-                        })}
-                    >
+                <p className={css({ color: "colorPalette.fg.muted" })}>
+                    &copy; {currentYear} Morinoparty. All rights reserved.
+                </p>
+                <nav className={hstack({ gap: "6" })}>
+                    <Link to="/docs/$" params={{ _splat: "getting-started/introduction" }} className={footerLink}>
                         Docs
                     </Link>
-                    <Link
-                        to="/docs/$"
-                        params={{ _splat: "theme" }}
-                        className={css({
-                            color: "colorPalette.fg.muted",
-                            textDecoration: "none",
-                            _hover: { color: "colorPalette.fg" },
-                        })}
-                    >
+                    <Link to="/docs/$" params={{ _splat: "theme" }} className={footerLink}>
                         Theme
                     </Link>
                     <a
                         href="https://github.com/morinoparty/chlorophyll"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={css({
-                            color: "colorPalette.fg.muted",
-                            textDecoration: "none",
-                            _hover: { color: "colorPalette.fg" },
-                        })}
+                        className={footerLink}
                     >
                         GitHub
                     </a>
-                </div>
-            </div>
-
-            {/* Copyright */}
-            <div
-                className={css({
-                    maxWidth: "7xl",
-                    marginX: "auto",
-                    paddingX: { base: "4", md: "6" },
-                    paddingY: "4",
-                    borderTop: "[1px solid]",
-                    borderColor: "border",
-                })}
-            >
-                <p className={css({ fontSize: "sm", color: "colorPalette.fg.muted" })}>
-                    &copy; {currentYear} Morinoparty. All rights reserved.
-                </p>
+                </nav>
             </div>
         </footer>
     );

--- a/docs/app/components/footer/index.tsx
+++ b/docs/app/components/footer/index.tsx
@@ -10,25 +10,17 @@ const footerLink = css({
     _hover: { color: "colorPalette.fg" },
 });
 
-// park-ui / shadcn のトップページに倣った 1 行だけの最小フッター。
-// 左にコピーライト、右に主要リンクを並べる
+// park-ui のトップに倣った、境界線を引かない 1 行だけの最小フッター。
+// 余白だけでコンテンツと区切り、ヘッダーと同じ横幅の使い方に揃える
 export function Footer() {
     const currentYear = new Date().getFullYear();
 
     return (
-        <footer
-            className={css({
-                borderTop: "[1px solid]",
-                borderColor: "border.subtle",
-                marginTop: "auto",
-            })}
-        >
+        <footer className={css({ marginTop: "auto" })}>
             <div
                 className={flex({
-                    maxWidth: "6xl",
-                    marginX: "auto",
                     paddingX: { base: "5", md: "8" },
-                    paddingY: "6",
+                    paddingY: "8",
                     flexDirection: { base: "column", sm: "row" },
                     justifyContent: "space-between",
                     alignItems: { base: "start", sm: "center" },

--- a/docs/app/components/header/index.tsx
+++ b/docs/app/components/header/index.tsx
@@ -13,6 +13,9 @@ const headerStyles = sva({
             zIndex: "overlay",
             bg: "bg/80",
             backdropFilter: "[blur(8px)]",
+            // スクロール時にコンテンツと混ざらないよう、下辺に淡い境界線を敷く
+            borderBottom: "[1px solid]",
+            borderColor: "border.subtle",
         },
         container: {
             display: "flex",
@@ -41,15 +44,15 @@ const headerStyles = sva({
         rightSection: {
             display: "flex",
             alignItems: "center",
-            gap: { base: "4", md: "16" },
+            gap: { base: "4", md: "8" },
         },
         nav: {
             display: { base: "none", md: "flex" },
             alignItems: "center",
-            gap: "8",
+            gap: "6",
         },
         navLink: {
-            fontSize: "md",
+            fontSize: "sm",
             fontWeight: "medium",
             color: "colorPalette.fg.muted",
             textDecoration: "none",

--- a/docs/app/components/header/index.tsx
+++ b/docs/app/components/header/index.tsx
@@ -1,27 +1,23 @@
 import { Link } from "@tanstack/react-router";
 import { Github } from "lucide-react";
-import { css, sva } from "styled-system/css";
+import { sva } from "styled-system/css";
 import { ColorPaletteToggle } from "../color-palette-toggle";
 import { MobileNav } from "../mobile-nav";
 
 const headerStyles = sva({
-    slots: ["root", "container", "logo", "logoIcon", "logoText", "rightSection", "nav", "navLink", "icons", "iconLink"],
+    slots: ["root", "container", "logo", "logoIcon", "logoText", "rightSection", "nav", "navLink", "iconButton"],
     base: {
         root: {
             position: "sticky",
             top: "0",
             zIndex: "overlay",
-            bg: "bg/80",
-            backdropFilter: "[blur(8px)]",
-            // スクロール時にコンテンツと混ざらないよう、下辺に淡い境界線を敷く
-            borderBottom: "[1px solid]",
-            borderColor: "border.subtle",
+            bg: "bg/70",
+            backdropFilter: "[blur(12px)]",
         },
+        // park-ui のトップに倣い、コンテナ幅で縛らず画面端までを使う
         container: {
             display: "flex",
-            maxWidth: "7xl",
-            marginX: "auto",
-            paddingX: { base: "4" },
+            paddingX: { base: "5", md: "8" },
             height: "16",
             alignItems: "center",
             justifyContent: "space-between",
@@ -29,53 +25,64 @@ const headerStyles = sva({
         logo: {
             display: "flex",
             alignItems: "center",
-            gap: "4",
+            gap: "3",
             textDecoration: "none",
             color: "colorPalette.fg",
         },
         logoIcon: {
-            width: "10",
-            height: "[37px]",
+            width: "8",
+            height: "8",
         },
         logoText: {
             fontWeight: "bold",
-            fontSize: "xl",
+            fontSize: "lg",
         },
         rightSection: {
             display: "flex",
             alignItems: "center",
-            gap: { base: "4", md: "8" },
+            gap: "2",
         },
         nav: {
             display: { base: "none", md: "flex" },
             alignItems: "center",
-            gap: "6",
+            gap: "1",
+            marginRight: "2",
         },
+        // 枠線を使わず、hover で淡い面を敷くゴーストボタン型のリンク
         navLink: {
+            display: "inline-flex",
+            alignItems: "center",
+            paddingX: "3",
+            paddingY: "2",
+            borderRadius: "lg",
             fontSize: "sm",
             fontWeight: "medium",
             color: "colorPalette.fg.muted",
             textDecoration: "none",
             transition: "colors",
-            _hover: { color: "colorPalette.fg" },
+            _hover: {
+                color: "colorPalette.fg",
+                bg: "colorPalette.surface",
+            },
         },
-        icons: {
-            display: "flex",
-            alignItems: "center",
-            gap: "4",
-        },
-        iconLink: {
-            display: "flex",
+        // アイコン類も同じゴーストボタン型に揃える
+        iconButton: {
+            display: { base: "none", md: "flex" },
             alignItems: "center",
             justifyContent: "center",
-            width: { base: "5", lg: "6" },
-            height: { base: "5", lg: "6" },
+            width: "9",
+            height: "9",
+            borderRadius: "lg",
             color: "colorPalette.fg.muted",
+            cursor: "pointer",
             transition: "colors",
-            _hover: { color: "colorPalette.fg" },
+            _hover: {
+                color: "colorPalette.fg",
+                bg: "colorPalette.surface",
+            },
             "& svg": {
-                width: { base: "5", lg: "6" },
-                height: { base: "5", lg: "6" },
+                width: "5",
+                height: "5",
             },
         },
     },
@@ -109,26 +116,16 @@ export function Header() {
                         </Link>
                     </nav>
 
-                    {/* Icons - hidden on mobile */}
-                    <div className={styles.icons}>
-                        <a
-                            href="https://github.com/morinoparty/chlorophyll"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={styles.iconLink}
-                            aria-label="GitHub"
-                        >
-                            <Github
-                                className={css({
-                                    display: {
-                                        base: "none",
-                                        lg: "block",
-                                    },
-                                })}
-                            />
-                        </a>
-                        <ColorPaletteToggle className={styles.iconLink} />
-                    </div>
+                    <a
+                        href="https://github.com/morinoparty/chlorophyll"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.iconButton}
+                        aria-label="GitHub"
+                    >
+                        <Github />
+                    </a>
+                    <ColorPaletteToggle className={styles.iconButton} />
 
                     {/* Mobile Navigation - visible only on mobile */}
                     <MobileNav />

--- a/docs/app/routes/index.tsx
+++ b/docs/app/routes/index.tsx
@@ -26,25 +26,27 @@ const homeStyles = sva({
         "demoStack",
     ],
     base: {
+        // park-ui のデスクトップレイアウトに倣い、xl 以上では
+        // 左にテキスト・右にデモカードのコラージュを並べて横幅いっぱいを使う
         root: {
-            display: "flex",
-            flexDirection: "column",
-            gap: { base: "12", md: "16" },
-            maxWidth: "6xl",
+            display: "grid",
+            gridTemplateColumns: { base: "1fr", xl: "[minmax(0, 30rem) 1fr]" },
+            alignItems: "center",
+            gap: { base: "12", xl: "16" },
+            maxWidth: "[120rem]",
             marginX: "auto",
-            paddingX: { base: "5", md: "8" },
+            paddingX: { base: "5", md: "8", xl: "12" },
             paddingY: { base: "10", md: "16" },
         },
 
         // --- Hero -------------------------------------------------------
-        // shadcn のトップページに倣い、中央揃えの見出しと CTA だけで構成する
         hero: {
             display: "flex",
             flexDirection: "column",
-            alignItems: "center",
-            textAlign: "center",
+            alignItems: { base: "center", xl: "start" },
+            textAlign: { base: "center", xl: "left" },
             gap: "5",
-            paddingY: { base: "6", md: "10" },
+            paddingY: { base: "6", xl: "10" },
             animation: "[chl-enter 500ms ease-out both]",
         },
         eyebrow: {
@@ -77,7 +79,7 @@ const homeStyles = sva({
             display: "flex",
             gap: "3",
             flexWrap: "wrap",
-            justifyContent: "center",
+            justifyContent: { base: "center", xl: "start" },
             marginTop: "2",
         },
 
@@ -85,10 +87,11 @@ const homeStyles = sva({
         // 実コンポーネントを組み込んだデモカードを masonry 状に敷き詰める。
         // カードの様式は demoCard の 1 種類だけに揃え、hover では動かさない
         showcase: {
-            columnCount: { base: 1, sm: 2, lg: 3 },
+            columnCount: { base: 1, sm: 2, "2xl": 3 },
             columnGap: "5",
             animation: "[chl-enter 500ms ease-out both]",
         },
+        // 枠線は引かず、白い面と柔らかい影だけでカードを浮かせる
         demoCard: {
             display: "flex",
             flexDirection: "column",
@@ -96,11 +99,9 @@ const homeStyles = sva({
             breakInside: "avoid",
             marginBottom: "5",
             padding: "5",
-            borderRadius: "2xl",
+            borderRadius: "3xl",
             bg: "colorPalette.bg",
-            border: "[1px solid]",
-            borderColor: "border",
-            boxShadow: "xs",
+            boxShadow: "md",
         },
         demoHead: {
             display: "flex",

--- a/docs/app/routes/index.tsx
+++ b/docs/app/routes/index.tsx
@@ -1,6 +1,6 @@
 import { Accordion, Badge, Button, GuideCard, List, NewsCard, PlayerPhraseCard } from "@morinoparty/chlorophyll-react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { sva } from "styled-system/css";
+import { cx, sva } from "styled-system/css";
 
 export const Route = createFileRoute("/")({
     head: () => ({
@@ -19,6 +19,13 @@ const homeStyles = sva({
         "actions",
         "showcase",
         "demoCard",
+        "demoCardFlush",
+        "demoCardTinted",
+        "demoCardInverted",
+        "flushThumb",
+        "flushBody",
+        "invertedTitle",
+        "invertedLead",
         "demoHead",
         "demoTitle",
         "demoLead",
@@ -91,7 +98,9 @@ const homeStyles = sva({
             columnGap: "5",
             animation: "[chl-enter 500ms ease-out both]",
         },
-        // 枠線は引かず、白い面と柔らかい影だけでカードを浮かせる
+        // 枠線は引かず、白い面と柔らかい影だけでカードを浮かせる。
+        // 単調にならないよう、白のほかに flush(画像フルブリード)/ tinted(淡色)/
+        // inverted(濃色)の面バリエーションを重ねて使う
         demoCard: {
             display: "flex",
             flexDirection: "column",
@@ -102,6 +111,37 @@ const homeStyles = sva({
             borderRadius: "3xl",
             bg: "colorPalette.bg",
             boxShadow: "md",
+        },
+        // 画像をカードの縁までフルブリードさせるメディアカード
+        demoCardFlush: {
+            padding: "0",
+            overflow: "hidden",
+        },
+        flushThumb: {
+            borderRadius: "[0px]",
+        },
+        flushBody: {
+            display: "grid",
+            gap: "4",
+            paddingX: "5",
+            paddingBottom: "5",
+        },
+        // 淡いブランド色の面を張ったカード
+        demoCardTinted: {
+            bg: "colorPalette.surface",
+        },
+        // 濃いブランド色で反転させたカード。白いボタンを際立たせる
+        demoCardInverted: {
+            bg: "colorPalette.bg.secondary",
+        },
+        invertedTitle: {
+            fontSize: "md",
+            fontWeight: "bold",
+            color: "colorPalette.fg.secondary",
+        },
+        invertedLead: {
+            fontSize: "sm",
+            color: "colorPalette.fg.secondary/80",
         },
         demoHead: {
             display: "flex",
@@ -169,28 +209,34 @@ function Home() {
 
             {/* Showcase: 実際の利用シーンを模したデモカード群 */}
             <section className={styles.showcase} data-chl-enter style={enterStyle(1)}>
-                {/* NewsCard: お知らせ記事のデモ */}
-                <div className={styles.demoCard}>
+                {/* NewsCard: お知らせ記事のデモ。画像をカードの縁までフルブリードさせる */}
+                <div className={cx(styles.demoCard, styles.demoCardFlush)}>
                     <NewsCard.Root>
-                        <NewsCard.Thumbnail src="/castle-width.png" alt="モリノパーティの城" />
-                        <NewsCard.Content>
-                            <NewsCard.Category>お知らせ</NewsCard.Category>
-                            <NewsCard.Title>夏の建築コンテストを開催します</NewsCard.Title>
-                        </NewsCard.Content>
-                        <NewsCard.Footer>
-                            <NewsCard.Date dateTime="2026-07-15">2026年7月15日</NewsCard.Date>
-                            <NewsCard.Author
-                                players={[
-                                    { playerId: "069a79f4-44e9-4726-a5be-fca90e38aaf5", playerName: "Notch" },
-                                    { playerId: "853c80ef-3c37-49fd-aa49-938b674adae6", playerName: "jeb_" },
-                                ]}
-                            />
-                        </NewsCard.Footer>
+                        <NewsCard.Thumbnail
+                            src="/castle-width.png"
+                            alt="モリノパーティの城"
+                            className={styles.flushThumb}
+                        />
+                        <div className={styles.flushBody}>
+                            <NewsCard.Content>
+                                <NewsCard.Category>お知らせ</NewsCard.Category>
+                                <NewsCard.Title>夏の建築コンテストを開催します</NewsCard.Title>
+                            </NewsCard.Content>
+                            <NewsCard.Footer>
+                                <NewsCard.Date dateTime="2026-07-15">2026年7月15日</NewsCard.Date>
+                                <NewsCard.Author
+                                    players={[
+                                        { playerId: "069a79f4-44e9-4726-a5be-fca90e38aaf5", playerName: "Notch" },
+                                        { playerId: "853c80ef-3c37-49fd-aa49-938b674adae6", playerName: "jeb_" },
+                                    ]}
+                                />
+                            </NewsCard.Footer>
+                        </div>
                     </NewsCard.Root>
                 </div>
 
-                {/* PlayerPhraseCard: メンバー紹介のデモ */}
-                <div className={styles.demoCard}>
+                {/* PlayerPhraseCard: メンバー紹介のデモ。淡いブランド色の面で変化を付ける */}
+                <div className={cx(styles.demoCard, styles.demoCardTinted)}>
                     <div className={styles.demoHead}>
                         <span className={styles.demoTitle}>メンバー</span>
                     </div>
@@ -301,21 +347,15 @@ function Home() {
                     </div>
                 </div>
 
-                {/* Button: intent バリエーションのデモ */}
-                <div className={styles.demoCard}>
+                {/* Button: 濃色の反転カード。白い secondary ボタンを際立たせてリズムを作る */}
+                <div className={cx(styles.demoCard, styles.demoCardInverted)}>
                     <div className={styles.demoHead}>
-                        <span className={styles.demoTitle}>イベントを作成</span>
-                        <span className={styles.demoLead}>建築コンテストやツアーを企画しよう。</span>
+                        <span className={styles.invertedTitle}>イベントを作成</span>
+                        <span className={styles.invertedLead}>建築コンテストやツアーを企画しよう。</span>
                     </div>
                     <div className={styles.demoRow}>
-                        <Button intent="primary" size="sm">
-                            作成する
-                        </Button>
                         <Button intent="secondary" size="sm">
-                            下書き
-                        </Button>
-                        <Button intent="plain" size="sm">
-                            キャンセル
+                            作成する
                         </Button>
                     </div>
                 </div>

--- a/docs/app/routes/index.tsx
+++ b/docs/app/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Badge, Button, GuideCard, List, NewsCard } from "@morinoparty/chlorophyll-react";
+import { Accordion, Badge, Button, GuideCard, List, NewsCard, PlayerPhraseCard } from "@morinoparty/chlorophyll-react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { sva } from "styled-system/css";
 
@@ -13,55 +13,38 @@ const homeStyles = sva({
     slots: [
         "root",
         "hero",
-        "heroLeft",
         "eyebrow",
         "title",
         "tagline",
         "actions",
-        "heroCollage",
-        "collageNews",
-        "collageBadges",
-        "collageButtons",
-        "sections",
         "showcase",
-        "showcaseHead",
-        "showcaseTitle",
-        "showcaseLead",
-        "showcaseGrid",
-        "tile",
-        "tileHead",
-        "tileTitle",
-        "tileBody",
-        "tileRow",
-        "tileLink",
+        "demoCard",
+        "demoHead",
+        "demoTitle",
+        "demoLead",
+        "demoRow",
+        "demoStack",
     ],
     base: {
         root: {
             display: "flex",
             flexDirection: "column",
-            // 各セクションの間隔。上下にたっぷり余白を取り、要素同士を呼吸させる
-            gap: { base: "16", md: "24" },
+            gap: { base: "12", md: "16" },
             maxWidth: "6xl",
             marginX: "auto",
             paddingX: { base: "5", md: "8" },
-            paddingY: { base: "12", md: "20" },
+            paddingY: { base: "10", md: "16" },
         },
 
         // --- Hero -------------------------------------------------------
+        // shadcn のトップページに倣い、中央揃えの見出しと CTA だけで構成する
         hero: {
-            display: "grid",
-            // モバイルは 1 カラム、md 以上でテキストとコラージュを左右に並べる
-            gridTemplateColumns: { base: "1fr", md: "[1.1fr 1fr]" },
-            gap: { base: "10", md: "16" },
-            alignItems: "center",
-        },
-        heroLeft: {
             display: "flex",
             flexDirection: "column",
-            alignItems: { base: "center", md: "start" },
-            textAlign: { base: "center", md: "left" },
+            alignItems: "center",
+            textAlign: "center",
             gap: "5",
-            // 入場アニメーション本体。遅延だけは要素ごとに inline で付与する
+            paddingY: { base: "6", md: "10" },
             animation: "[chl-enter 500ms ease-out both]",
         },
         eyebrow: {
@@ -77,142 +60,79 @@ const homeStyles = sva({
             bg: "colorPalette.surface",
         },
         title: {
-            // 長い見出しでも折り返しが自然になるよう balance を使う
             textWrap: "balance",
-            fontSize: { base: "4xl", md: "5xl" },
+            fontSize: { base: "4xl", md: "6xl" },
             fontWeight: "bold",
             lineHeight: "tight",
             color: "colorPalette.fg",
         },
         tagline: {
-            // 本文は行末をなだらかにする pretty で読みやすくする
             textWrap: "[pretty]",
             fontSize: { base: "md", md: "lg" },
             lineHeight: "relaxed",
             color: "colorPalette.fg.muted",
-            maxWidth: "md",
+            maxWidth: "xl",
         },
         actions: {
             display: "flex",
             gap: "3",
             flexWrap: "wrap",
-            justifyContent: { base: "center", md: "start" },
+            justifyContent: "center",
             marginTop: "2",
         },
 
-        // --- Hero collage ----------------------------------------------
-        // パネルで囲わず、ページ背景の上にカード・バッジ・ボタンをそのまま浮かべる。
-        // 面を重ねすぎるとカードだらけに見えるため、白い面は NewsCard の 1 枚だけにする
-        heroCollage: {
-            display: "flex",
-            flexDirection: "column",
-            gap: "4",
-            animation: "[chl-enter 500ms ease-out both]",
-        },
-        collageNews: {
-            padding: "4",
-            borderRadius: "3xl",
-            bg: "colorPalette.bg",
-            border: "[1px solid]",
-            borderColor: "border",
-            boxShadow: "sm",
-        },
-        collageBadges: {
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "2",
-        },
-        collageButtons: {
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "3",
-        },
-
-        // --- GuideCard sections ----------------------------------------
-        sections: {
-            display: "grid",
-            gridTemplateColumns: { base: "1fr", md: "[repeat(2, 1fr)]" },
-            gap: "5",
-            animation: "[chl-enter 500ms ease-out both]",
-        },
-
         // --- Component showcase ----------------------------------------
+        // 実コンポーネントを組み込んだデモカードを masonry 状に敷き詰める。
+        // カードの様式は demoCard の 1 種類だけに揃え、hover では動かさない
         showcase: {
-            display: "flex",
-            flexDirection: "column",
-            gap: "8",
+            columnCount: { base: 1, sm: 2, lg: 3 },
+            columnGap: "5",
             animation: "[chl-enter 500ms ease-out both]",
         },
-        showcaseHead: {
-            display: "flex",
-            flexDirection: "column",
-            gap: "2",
-            alignItems: { base: "center", md: "start" },
-            textAlign: { base: "center", md: "left" },
-        },
-        showcaseTitle: {
-            textWrap: "balance",
-            fontSize: { base: "3xl", md: "4xl" },
-            fontWeight: "bold",
-            color: "colorPalette.fg",
-        },
-        showcaseLead: {
-            textWrap: "[pretty]",
-            fontSize: "md",
-            color: "colorPalette.fg.muted",
-            maxWidth: "xl",
-        },
-        showcaseGrid: {
-            display: "grid",
-            gridTemplateColumns: { base: "1fr", sm: "[repeat(2, 1fr)]" },
-            gap: "5",
-        },
-        // 個々のタイル。外側 radius = 内側 radius(xl) + padding(3) の同心円になるよう 3xl を選ぶ
-        tile: {
+        demoCard: {
             display: "flex",
             flexDirection: "column",
             gap: "4",
-            padding: "6",
-            borderRadius: "3xl",
+            breakInside: "avoid",
+            marginBottom: "5",
+            padding: "5",
+            borderRadius: "2xl",
             bg: "colorPalette.bg",
             border: "[1px solid]",
             borderColor: "border",
-            // タイル自体はクリックできないデモ用の面なので、hover では動かさない
-            boxShadow: "sm",
+            boxShadow: "xs",
         },
-        tileHead: {
+        demoHead: {
             display: "flex",
             flexDirection: "column",
             gap: "1",
         },
-        tileTitle: {
-            fontSize: "lg",
+        demoTitle: {
+            fontSize: "md",
             fontWeight: "bold",
             color: "colorPalette.fg",
         },
-        tileBody: {
-            display: "flex",
-            flexDirection: "column",
-            gap: "3",
-            flex: "1",
+        demoLead: {
+            fontSize: "sm",
+            color: "colorPalette.fg.muted",
         },
-        tileRow: {
+        demoRow: {
             display: "flex",
             flexWrap: "wrap",
             gap: "2",
             alignItems: "center",
         },
-        tileLink: {
-            alignSelf: "start",
-            fontSize: "sm",
-            fontWeight: "medium",
-            color: "colorPalette.fg.muted",
-            textDecoration: "none",
-            transition: "colors",
-            _hover: { color: "colorPalette.fg" },
+        demoStack: {
+            display: "flex",
+            flexDirection: "column",
+            gap: "3",
         },
     },
 });
+
+// PlayerPhraseCard のフレーズ生成を SSR とクライアントで一致させるための固定基準時刻。
+// 未指定だと現在時刻が使われ、hydration mismatch の原因になる
+const PHRASE_REFERENCE_TIME = new Date("2026-07-15T00:00:00+09:00").getTime();
 
 // 各セクションの入場アニメーションを 80ms 刻みでずらすためのヘルパー。
 // アニメーション本体は sva 側で定義し、ここでは遅延だけを要素ごとに与える。
@@ -229,46 +149,83 @@ function Home() {
     return (
         <div className={styles.root}>
             {/* Hero */}
-            <section className={styles.hero}>
-                <div className={styles.heroLeft} data-chl-enter style={enterStyle(0)}>
-                    <span className={styles.eyebrow}>Morinoparty Design System</span>
-                    <h1 className={styles.title}>Chlorophyll</h1>
-                    <p className={styles.tagline}>
-                        Panda CSS と Ark UI で組んだ、モリノパーティのためのコンポーネントライブラリ。トークンから
-                        コンポーネントまで、一貫したデザインをすばやく組み立てられる。
-                    </p>
-                    <div className={styles.actions}>
-                        <Link to="/docs/$" params={{ _splat: "getting-started/introduction" }}>
-                            <Button intent="primary">ドキュメントへ</Button>
-                        </Link>
-                        <Link to="/docs/$" params={{ _splat: "theme" }}>
-                            <Button intent="secondary">トークン一覧</Button>
-                        </Link>
+            <section className={styles.hero} data-chl-enter style={enterStyle(0)}>
+                <span className={styles.eyebrow}>Morinoparty Design System</span>
+                <h1 className={styles.title}>Chlorophyll</h1>
+                <p className={styles.tagline}>
+                    Panda CSS と Ark UI で組んだ、モリノパーティのためのコンポーネントライブラリ。トークンから
+                    コンポーネントまで、一貫したデザインをすばやく組み立てられる。
+                </p>
+                <div className={styles.actions}>
+                    <Link to="/docs/$" params={{ _splat: "getting-started/introduction" }}>
+                        <Button intent="primary">ドキュメントへ</Button>
+                    </Link>
+                    <Link to="/docs/$" params={{ _splat: "theme" }}>
+                        <Button intent="secondary">トークン一覧</Button>
+                    </Link>
+                </div>
+            </section>
+
+            {/* Showcase: 実際の利用シーンを模したデモカード群 */}
+            <section className={styles.showcase} data-chl-enter style={enterStyle(1)}>
+                {/* NewsCard: お知らせ記事のデモ */}
+                <div className={styles.demoCard}>
+                    <NewsCard.Root>
+                        <NewsCard.Thumbnail src="/castle-width.png" alt="モリノパーティの城" />
+                        <NewsCard.Content>
+                            <NewsCard.Category>お知らせ</NewsCard.Category>
+                            <NewsCard.Title>夏の建築コンテストを開催します</NewsCard.Title>
+                        </NewsCard.Content>
+                        <NewsCard.Footer>
+                            <NewsCard.Date dateTime="2026-07-15">2026年7月15日</NewsCard.Date>
+                            <NewsCard.Author
+                                players={[
+                                    { playerId: "069a79f4-44e9-4726-a5be-fca90e38aaf5", playerName: "Notch" },
+                                    { playerId: "853c80ef-3c37-49fd-aa49-938b674adae6", playerName: "jeb_" },
+                                ]}
+                            />
+                        </NewsCard.Footer>
+                    </NewsCard.Root>
+                </div>
+
+                {/* PlayerPhraseCard: メンバー紹介のデモ */}
+                <div className={styles.demoCard}>
+                    <div className={styles.demoHead}>
+                        <span className={styles.demoTitle}>メンバー</span>
+                    </div>
+                    <div className={styles.demoStack}>
+                        <PlayerPhraseCard
+                            playerId="389b1a68-f647-4dd0-a421-61b6c22fdebe"
+                            playerName="Chocolatt"
+                            referenceTime={PHRASE_REFERENCE_TIME}
+                        >
+                            <PlayerPhraseCard.Avatar />
+                            <PlayerPhraseCard.Body>
+                                <PlayerPhraseCard.Phrase />
+                                <PlayerPhraseCard.Name />
+                            </PlayerPhraseCard.Body>
+                        </PlayerPhraseCard>
+                        <PlayerPhraseCard
+                            playerId="75ba1a8c-4e02-4b4b-abe3-92ef4af6147c"
+                            playerName="Yahirrro"
+                            referenceTime={PHRASE_REFERENCE_TIME}
+                        >
+                            <PlayerPhraseCard.Avatar />
+                            <PlayerPhraseCard.Body>
+                                <PlayerPhraseCard.Phrase />
+                                <PlayerPhraseCard.Name />
+                            </PlayerPhraseCard.Body>
+                        </PlayerPhraseCard>
                     </div>
                 </div>
 
-                {/* コラージュ: colorPalette トークンで塗り、ヘッダーのパレット切り替えで再テーマされる */}
-                <div className={styles.heroCollage} data-chl-enter style={enterStyle(1)}>
-                    <div className={styles.collageNews}>
-                        <NewsCard.Root>
-                            <NewsCard.Thumbnail src="/castle-width.png" alt="モリノパーティの城" />
-                            <NewsCard.Content>
-                                <NewsCard.Category>お知らせ</NewsCard.Category>
-                                <NewsCard.Title>夏の建築コンテストを開催します</NewsCard.Title>
-                            </NewsCard.Content>
-                            <NewsCard.Footer>
-                                <NewsCard.Date dateTime="2026-07-15">2026年7月15日</NewsCard.Date>
-                                <NewsCard.Author
-                                    players={[
-                                        { playerId: "069a79f4-44e9-4726-a5be-fca90e38aaf5", playerName: "Notch" },
-                                        { playerId: "853c80ef-3c37-49fd-aa49-938b674adae6", playerName: "jeb_" },
-                                    ]}
-                                />
-                            </NewsCard.Footer>
-                        </NewsCard.Root>
+                {/* Badge + List + Button: サーバー参加フローのデモ */}
+                <div className={styles.demoCard}>
+                    <div className={styles.demoHead}>
+                        <span className={styles.demoTitle}>サーバーに参加する</span>
+                        <span className={styles.demoLead}>今日から建築をはじめよう。</span>
                     </div>
-
-                    <div className={styles.collageBadges}>
+                    <div className={styles.demoRow}>
                         <Badge status="success" dot>
                             オンライン
                         </Badge>
@@ -278,158 +235,87 @@ function Home() {
                         <Badge status="warning" variant="surface">
                             メンテ予定
                         </Badge>
-                        <Badge status="error" variant="outline">
-                            満員
-                        </Badge>
                     </div>
-
-                    <div className={styles.collageButtons}>
+                    <List variant="ghost" size="sm">
+                        <List.Item>サーバーに参加する</List.Item>
+                        <List.Item>ルールを確認する</List.Item>
+                        <List.Item>建築を始める</List.Item>
+                    </List>
+                    <div className={styles.demoRow}>
                         <Button intent="primary" size="sm">
                             参加する
-                        </Button>
-                        <Button intent="secondary" size="sm">
-                            詳細
                         </Button>
                         <Button intent="plain" size="sm">
                             あとで
                         </Button>
                     </div>
                 </div>
-            </section>
 
-            {/* Sections: GuideCard で主要な入り口へ誘導する */}
-            <section className={styles.sections} data-chl-enter style={enterStyle(2)}>
-                <GuideCard.Root asChild>
-                    <Link to="/docs/$" params={{ _splat: "getting-started/introduction" }}>
-                        <GuideCard.Image src="/castle-width.png" alt="はじめに" />
-                        <GuideCard.Content>
-                            <GuideCard.Title>はじめに</GuideCard.Title>
-                            <GuideCard.Description>
-                                インストールからセットアップまで、Chlorophyll を使い始めるための手引き。
-                            </GuideCard.Description>
-                        </GuideCard.Content>
-                    </Link>
-                </GuideCard.Root>
-
-                <GuideCard.Root asChild>
-                    <Link to="/docs/$" params={{ _splat: "theme" }}>
-                        <GuideCard.Image src="/castle-tall.png" alt="トークン" />
-                        <GuideCard.Content>
-                            <GuideCard.Title>トークン</GuideCard.Title>
-                            <GuideCard.Description>
-                                色・余白・タイポグラフィなど、デザインの土台となるトークン一覧。
-                            </GuideCard.Description>
-                        </GuideCard.Content>
-                    </Link>
-                </GuideCard.Root>
-            </section>
-
-            {/* Component showcase */}
-            <section className={styles.showcase} data-chl-enter style={enterStyle(3)}>
-                <div className={styles.showcaseHead}>
-                    <h2 className={styles.showcaseTitle}>コンポーネント</h2>
-                    <p className={styles.showcaseLead}>
-                        バッジやボタン、リスト、アコーディオンなど、そのまま使える実コンポーネントを揃えている。
-                    </p>
+                {/* Accordion: よくある質問のデモ */}
+                <div className={styles.demoCard}>
+                    <div className={styles.demoHead}>
+                        <span className={styles.demoTitle}>よくある質問</span>
+                    </div>
+                    <Accordion.Root variant="ghost" collapsible defaultValue={["join"]}>
+                        <Accordion.Item value="join">
+                            <Accordion.ItemTrigger>参加方法は？</Accordion.ItemTrigger>
+                            <Accordion.ItemContent>
+                                サーバーアドレスを追加して、そのまま接続すれば参加できる。
+                            </Accordion.ItemContent>
+                        </Accordion.Item>
+                        <Accordion.Item value="rule">
+                            <Accordion.ItemTrigger>ルールはある？</Accordion.ItemTrigger>
+                            <Accordion.ItemContent>
+                                他のプレイヤーの建築を壊さないなど、いくつかの約束がある。
+                            </Accordion.ItemContent>
+                        </Accordion.Item>
+                    </Accordion.Root>
                 </div>
 
-                <div className={styles.showcaseGrid}>
-                    {/* Badge */}
-                    <div className={styles.tile}>
-                        <div className={styles.tileHead}>
-                            <span className={styles.tileTitle}>Badge</span>
-                        </div>
-                        <div className={styles.tileBody}>
-                            <div className={styles.tileRow}>
-                                <Badge status="success">成功</Badge>
-                                <Badge status="info" variant="subtle">
-                                    情報
-                                </Badge>
-                                <Badge status="warning" variant="surface">
-                                    警告
-                                </Badge>
-                                <Badge status="error" variant="outline">
-                                    エラー
-                                </Badge>
-                            </div>
-                        </div>
-                        <Link
-                            to="/docs/$"
-                            params={{ _splat: "theme/system-tokens/colors" }}
-                            className={styles.tileLink}
-                        >
-                            カラートークンを見る →
-                        </Link>
+                {/* GuideCard: ドキュメントへの入り口を兼ねたデモ */}
+                <div className={styles.demoCard}>
+                    <div className={styles.demoStack}>
+                        <GuideCard.Root asChild>
+                            <Link to="/docs/$" params={{ _splat: "getting-started/introduction" }}>
+                                <GuideCard.Image src="/castle-width.png" alt="はじめに" />
+                                <GuideCard.Content>
+                                    <GuideCard.Title>はじめに</GuideCard.Title>
+                                    <GuideCard.Description>
+                                        インストールからセットアップまでの手引き。
+                                    </GuideCard.Description>
+                                </GuideCard.Content>
+                            </Link>
+                        </GuideCard.Root>
+                        <GuideCard.Root asChild>
+                            <Link to="/docs/$" params={{ _splat: "theme" }}>
+                                <GuideCard.Image src="/castle-tall.png" alt="トークン" />
+                                <GuideCard.Content>
+                                    <GuideCard.Title>トークン</GuideCard.Title>
+                                    <GuideCard.Description>
+                                        色・余白・タイポグラフィなどの土台となるトークン一覧。
+                                    </GuideCard.Description>
+                                </GuideCard.Content>
+                            </Link>
+                        </GuideCard.Root>
                     </div>
+                </div>
 
-                    {/* Button */}
-                    <div className={styles.tile}>
-                        <div className={styles.tileHead}>
-                            <span className={styles.tileTitle}>Button</span>
-                        </div>
-                        <div className={styles.tileBody}>
-                            <div className={styles.tileRow}>
-                                <Button intent="primary" size="sm">
-                                    Primary
-                                </Button>
-                                <Button intent="secondary" size="sm">
-                                    Secondary
-                                </Button>
-                                <Button intent="plain" size="sm">
-                                    Plain
-                                </Button>
-                            </div>
-                        </div>
-                        <Link
-                            to="/docs/$"
-                            params={{ _splat: "getting-started/quick-start" }}
-                            className={styles.tileLink}
-                        >
-                            クイックスタート →
-                        </Link>
+                {/* Button: intent バリエーションのデモ */}
+                <div className={styles.demoCard}>
+                    <div className={styles.demoHead}>
+                        <span className={styles.demoTitle}>イベントを作成</span>
+                        <span className={styles.demoLead}>建築コンテストやツアーを企画しよう。</span>
                     </div>
-
-                    {/* List */}
-                    <div className={styles.tile}>
-                        <div className={styles.tileHead}>
-                            <span className={styles.tileTitle}>List</span>
-                        </div>
-                        <div className={styles.tileBody}>
-                            <List variant="ghost" size="sm">
-                                <List.Item>サーバーに参加する</List.Item>
-                                <List.Item>ルールを確認する</List.Item>
-                                <List.Item>建築を始める</List.Item>
-                            </List>
-                        </div>
-                        <Link to="/docs/$" params={{ _splat: "theme" }} className={styles.tileLink}>
-                            トークンを見る →
-                        </Link>
-                    </div>
-
-                    {/* Accordion */}
-                    <div className={styles.tile}>
-                        <div className={styles.tileHead}>
-                            <span className={styles.tileTitle}>Accordion</span>
-                        </div>
-                        <div className={styles.tileBody}>
-                            <Accordion.Root variant="ghost" collapsible defaultValue={["join"]}>
-                                <Accordion.Item value="join">
-                                    <Accordion.ItemTrigger>参加方法は？</Accordion.ItemTrigger>
-                                    <Accordion.ItemContent>
-                                        サーバーアドレスを追加して、そのまま接続すれば参加できる。
-                                    </Accordion.ItemContent>
-                                </Accordion.Item>
-                                <Accordion.Item value="rule">
-                                    <Accordion.ItemTrigger>ルールはある？</Accordion.ItemTrigger>
-                                    <Accordion.ItemContent>
-                                        他のプレイヤーの建築を壊さないなど、いくつかの約束がある。
-                                    </Accordion.ItemContent>
-                                </Accordion.Item>
-                            </Accordion.Root>
-                        </div>
-                        <Link to="/docs/$" params={{ _splat: "concept/architecture" }} className={styles.tileLink}>
-                            設計を見る →
-                        </Link>
+                    <div className={styles.demoRow}>
+                        <Button intent="primary" size="sm">
+                            作成する
+                        </Button>
+                        <Button intent="secondary" size="sm">
+                            下書き
+                        </Button>
+                        <Button intent="plain" size="sm">
+                            キャンセル
+                        </Button>
                     </div>
                 </div>
             </section>

--- a/docs/app/routes/index.tsx
+++ b/docs/app/routes/index.tsx
@@ -101,21 +101,20 @@ const homeStyles = sva({
         },
 
         // --- Hero collage ----------------------------------------------
+        // パネルで囲わず、ページ背景の上にカード・バッジ・ボタンをそのまま浮かべる。
+        // 面を重ねすぎるとカードだらけに見えるため、白い面は NewsCard の 1 枚だけにする
         heroCollage: {
             display: "flex",
             flexDirection: "column",
             gap: "4",
-            // 淡い面のパネルに実コンポーネントを並べたショーケース
-            padding: { base: "5", md: "6" },
-            borderRadius: "4xl",
-            bg: "colorPalette.bg.subtle",
-            boxShadow: "lg",
             animation: "[chl-enter 500ms ease-out both]",
         },
         collageNews: {
             padding: "4",
             borderRadius: "3xl",
             bg: "colorPalette.bg",
+            border: "[1px solid]",
+            borderColor: "border",
             boxShadow: "sm",
         },
         collageBadges: {
@@ -178,15 +177,8 @@ const homeStyles = sva({
             bg: "colorPalette.bg",
             border: "[1px solid]",
             borderColor: "border",
-            // jakub.kr 流の重ねシャドウ。hover で少し浮き上がらせる
+            // タイル自体はクリックできないデモ用の面なので、hover では動かさない
             boxShadow: "sm",
-            transitionProperty: "[box-shadow, transform]",
-            transitionDuration: "normal",
-            transitionTimingFunction: "easeInOut",
-            _hover: {
-                boxShadow: "lg",
-                transform: "translateY(-2px)",
-            },
         },
         tileHead: {
             display: "flex",

--- a/packages/react/src/preset/token/recipes/button.ts
+++ b/packages/react/src/preset/token/recipes/button.ts
@@ -132,14 +132,16 @@ export const button = defineRecipe({
                 },
             },
         },
+        // park-ui (md: 40px) / shadcn (default: 36px) に近いスケール。
+        // 高さ・横 padding・文字サイズを 1 段ずつ連動させ、どこで並べても揃って見えるようにする
         size: {
-            sm: { height: "{sizes.10}", px: "{spacing.4}", fontSize: "xs" },
-            md: { height: "{sizes.11}", px: "{spacing.5}", fontSize: "sm" },
-            lg: { height: "{sizes.12}", px: "{spacing.6}", py: "{spacing.2}", fontSize: "md" },
+            sm: { height: "{sizes.9}", px: "{spacing.3.5}", fontSize: "xs" },
+            md: { height: "{sizes.10}", px: "{spacing.4}", fontSize: "sm" },
+            lg: { height: "{sizes.11}", px: "{spacing.5}", fontSize: "md" },
         },
     },
     defaultVariants: {
         intent: "primary",
-        size: "lg",
+        size: "md",
     },
 });

--- a/packages/react/src/preset/token/recipes/button.ts
+++ b/packages/react/src/preset/token/recipes/button.ts
@@ -142,6 +142,6 @@ export const button = defineRecipe({
     },
     defaultVariants: {
         intent: "primary",
-        size: "md",
+        size: "lg",
     },
 });

--- a/packages/react/src/preset/token/recipes/guide-card.ts
+++ b/packages/react/src/preset/token/recipes/guide-card.ts
@@ -22,6 +22,13 @@ export const guideCard = defineSlotRecipe({
             transitionProperty: "background, box-shadow",
             transitionDuration: "normal",
             transitionTimingFunction: "easeInOut",
+            // リンクとして使われるカードなので、hover / active で面の色を 1 段ずつ濃くして反応を返す
+            _hover: {
+                bg: "colorPalette.surface.hover",
+            },
+            _active: {
+                bg: "colorPalette.surface.active",
+            },
         },
         image: {
             width: "full",

--- a/packages/react/src/preset/token/recipes/news-card.ts
+++ b/packages/react/src/preset/token/recipes/news-card.ts
@@ -9,20 +9,12 @@ export const newsCard = defineSlotRecipe({
     slots: ["root", "thumbnail", "image", "content", "category", "title", "footer", "date", "authors", "author"],
     base: {
         root: {
-            position: "relative",
             display: "grid",
             gap: "4",
             height: "fit-content",
             color: "colorPalette.fg",
             textDecoration: "none",
             cursor: "pointer",
-            // hover フィードバックはカードの枠内に収める。
-            // 背後に面を敷く方式だとカード外へはみ出し、余白の狭い場所で崩れて見えるため、
-            // サムネイル画像をわずかにズームする方式にする。
-            // クラス名は prefix 設定で変わるため、要素セレクタでサムネイル画像を指す
-            _hover: {
-                "& :where(figure) img": { transform: "scale(1.04)" },
-            },
         },
         thumbnail: {
             display: "flex",
@@ -40,9 +32,6 @@ export const newsCard = defineSlotRecipe({
             width: "full",
             height: "full",
             objectFit: "cover",
-            transitionProperty: "transform",
-            transitionDuration: "normal",
-            transitionTimingFunction: "easeInOut",
         },
         content: {
             display: "grid",

--- a/packages/react/src/preset/token/recipes/news-card.ts
+++ b/packages/react/src/preset/token/recipes/news-card.ts
@@ -16,26 +16,12 @@ export const newsCard = defineSlotRecipe({
             color: "colorPalette.fg",
             textDecoration: "none",
             cursor: "pointer",
-            zIndex: "[1]",
-            // hover 時にカード全体の背後へふわっと広がるハイライト。
-            // カードより一回り(12px)大きい角丸の面を after 疑似要素で敷く
-            _after: {
-                content: '""',
-                position: "absolute",
-                top: "-3",
-                left: "-3",
-                width: "[calc(100% + token(spacing.6))]",
-                height: "[calc(100% + token(spacing.6))]",
-                bg: "colorPalette.a3",
-                borderRadius: "[token(radii.3xl) token(radii.3xl) token(radii.xl) token(radii.xl)]",
-                zIndex: "[-1]",
-                opacity: "0",
-                transitionProperty: "opacity",
-                transitionDuration: "normal",
-                transitionTimingFunction: "easeInOut",
-            },
+            // hover フィードバックはカードの枠内に収める。
+            // 背後に面を敷く方式だとカード外へはみ出し、余白の狭い場所で崩れて見えるため、
+            // サムネイル画像をわずかにズームする方式にする。
+            // クラス名は prefix 設定で変わるため、要素セレクタでサムネイル画像を指す
             _hover: {
-                _after: { opacity: "1" },
+                "& :where(figure) img": { transform: "scale(1.04)" },
             },
         },
         thumbnail: {
@@ -54,6 +40,9 @@ export const newsCard = defineSlotRecipe({
             width: "full",
             height: "full",
             objectFit: "cover",
+            transitionProperty: "transform",
+            transitionDuration: "normal",
+            transitionTimingFunction: "easeInOut",
         },
         content: {
             display: "grid",


### PR DESCRIPTION
## Summary
- トップページを shadcn / park-ui を参考に全面リデザイン
  - hero を中央揃え(見出し + タグライン + CTA のみ)に変更
  - 「紹介カード + デモタイル」の混在をやめ、実コンポーネント(NewsCard / PlayerPhraseCard / Badge / List / Accordion / GuideCard / Button)を組み込んだ統一様式のデモカードを masonry グリッドに敷き詰める構成へ
  - カードの hover 演出(はみ出すハイライト・画像ズーム・浮き上がり)をすべて廃止
- Button のサイズスケールを縮小(sm 36 / md 40 / lg 44px)。既定は普段づかい用の `lg`
- GuideCard に hover/active の背景フィードバックを追加(リンク用途のため)
- header に下辺の境界線を追加しギャップを調整、footer を 1 行の最小構成に書き換え
- PlayerPhraseCard に固定 `referenceTime` を渡して SSR の hydration mismatch を解消

## Test plan
- [x] `pnpm run check` が通ることを確認
- [x] Playwright でトップページ全体・hover 状態・ボタン実寸(高さ 36/40/44px)を確認
- [x] コンソールエラー 0 件(hydration mismatch 解消)を確認