### PR TITLE
✨ Add menu, drawer, modal-dialog, pagination, toast, tooltip, spinner & skeleton

### DIFF
--- a/packages/react/src/components/badge/index.tsx
+++ b/packages/react/src/components/badge/index.tsx
@@ -16,7 +16,7 @@ const STATUS_CLASS_NAME: Record<BadgeStatus, string> = {
 };
 
 interface BadgeProps extends HTMLArkProps<"span"> {
-    /** 見た目のスタイル。塗り(solid)・淡色(subtle)・枠線(outline)・淡色+枠線(surface) */
+    /** 見た目のスタイル。塗り(solid)・淡色(subtle)・枠線(outline)・淡色+枠線(surface)。既定は outline */
     variant?: "solid" | "subtle" | "outline" | "surface";
     /** タグの大きさ */
     size?: "sm" | "md";

--- a/packages/react/src/components/drawer/index.tsx
+++ b/packages/react/src/components/drawer/index.tsx
@@ -1,0 +1,105 @@
+"use client";
+import { Dialog as ArkDialog } from "@ark-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import type { ComponentProps } from "react";
+import { createContext, useContext } from "react";
+import { cx } from "styled-system/css";
+import { drawer } from "styled-system/recipes";
+
+// アンカー位置とスライド方向。start = 画面左、end = 画面右
+type DrawerPlacement = "start" | "end";
+
+// Portal は DOM の描画先を変えるだけで React ツリー(Context)は分断されないが、
+// Positioner/Content は独立した子コンポーネントとして呼び出されるため、
+// props のバケツリレーを避けて Context で placement を配る
+const DrawerPlacementContext = createContext<DrawerPlacement>("end");
+
+// placement に依存しないスロットは一度だけ解決すれば済む
+const styles = drawer();
+
+type DrawerRootProps = ComponentProps<typeof ArkDialog.Root> & {
+    /** スライド方向とアンカー位置。start(画面左) / end(画面右)。既定は end */
+    placement?: DrawerPlacement;
+};
+
+// Drawer 全体の開閉状態を管理する Root。zag の Dialog と同じく DOM は持たない
+const DrawerRoot = ({ placement = "end", ...props }: DrawerRootProps) => {
+    return (
+        <DrawerPlacementContext.Provider value={placement}>
+            <ArkDialog.Root {...props} />
+        </DrawerPlacementContext.Provider>
+    );
+};
+
+type DrawerTriggerProps = ComponentProps<typeof ArkDialog.Trigger>;
+
+// Drawer を開くトリガー。asChild で IconButton などに差し替え可能
+const DrawerTrigger = ({ className, ...props }: DrawerTriggerProps) => {
+    return <ArkDialog.Trigger {...props} className={cx(styles.trigger, className)} />;
+};
+
+type DrawerBackdropProps = ComponentProps<typeof ArkDialog.Backdrop>;
+
+// 画面全体を覆う半透明の暗転レイヤー。開いたときにフェードインする
+const DrawerBackdrop = ({ className, ...props }: DrawerBackdropProps) => {
+    return <ArkDialog.Backdrop {...props} className={cx(styles.backdrop, className)} />;
+};
+
+type DrawerPositionerProps = ComponentProps<typeof ArkDialog.Positioner>;
+
+// Content を画面端に寄せて配置するレイヤー。placement は Root から Context 経由で受け取る
+const DrawerPositioner = ({ className, ...props }: DrawerPositionerProps) => {
+    const placement = useContext(DrawerPlacementContext);
+    const positionerClass = drawer({ placement }).positioner;
+    return <ArkDialog.Positioner {...props} className={cx(positionerClass, className)} />;
+};
+
+type DrawerContentProps = ComponentProps<typeof ArkDialog.Content>;
+
+// 画面端からスライドインしてくるパネル本体
+const DrawerContent = ({ className, ...props }: DrawerContentProps) => {
+    const placement = useContext(DrawerPlacementContext);
+    const contentClass = drawer({ placement }).content;
+    return <ArkDialog.Content {...props} className={cx(contentClass, className)} />;
+};
+
+type DrawerCloseTriggerProps = ComponentProps<typeof ArkDialog.CloseTrigger>;
+
+// 閉じるボタン。children を渡さなければ既定で ×アイコンを表示する
+const DrawerCloseTrigger = ({ className, children, ...props }: DrawerCloseTriggerProps) => {
+    return (
+        <ArkDialog.CloseTrigger {...props} className={cx(styles.closeTrigger, className)}>
+            {children ?? <XIcon />}
+        </ArkDialog.CloseTrigger>
+    );
+};
+
+type DrawerTitleProps = ComponentProps<typeof ArkDialog.Title>;
+
+// 見出し
+const DrawerTitle = ({ className, ...props }: DrawerTitleProps) => {
+    return <ArkDialog.Title {...props} className={cx(styles.title, className)} />;
+};
+
+// Compound Component パターン: Drawer.Root / Trigger / Backdrop / Positioner / Content / CloseTrigger / Title
+const Drawer = Object.assign(DrawerRoot, {
+    Root: DrawerRoot,
+    Trigger: DrawerTrigger,
+    Backdrop: DrawerBackdrop,
+    Positioner: DrawerPositioner,
+    Content: DrawerContent,
+    CloseTrigger: DrawerCloseTrigger,
+    Title: DrawerTitle,
+});
+
+export { Drawer };
+export type {
+    DrawerRootProps,
+    DrawerTriggerProps,
+    DrawerBackdropProps,
+    DrawerPositionerProps,
+    DrawerContentProps,
+    DrawerCloseTriggerProps,
+    DrawerTitleProps,
+    DrawerPlacement,
+};

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -7,8 +7,31 @@ export {
 } from "./accordion";
 export { Badge, type BadgeProps } from "./badge";
 export { Button, type ButtonProps } from "./button";
+export {
+    Drawer,
+    type DrawerBackdropProps,
+    type DrawerCloseTriggerProps,
+    type DrawerContentProps,
+    type DrawerPlacement,
+    type DrawerPositionerProps,
+    type DrawerRootProps,
+    type DrawerTitleProps,
+    type DrawerTriggerProps,
+} from "./drawer";
 export { GuideCard } from "./guide-card";
 export { List, ListItem, type ListItemProps, type ListProps, type ListSize } from "./list";
+export {
+    Menu,
+    type MenuContentProps,
+    type MenuItemGroupLabelProps,
+    type MenuItemGroupProps,
+    type MenuItemProps,
+    type MenuItemVariant,
+    type MenuPositionerProps,
+    type MenuRootProps,
+    type MenuSeparatorProps,
+    type MenuTriggerProps,
+} from "./menu";
 export { MinecraftItem, type MinecraftItemProps, type ResolvedMinecraftItem } from "./minecraft-item";
 export {
     type MinecraftAssetsResolver,
@@ -19,12 +42,29 @@ export {
     useMinecraftConfig,
 } from "./minecraft-provider";
 export {
+    ModalDialog,
+    type ModalDialogContainerProps,
+    type ModalDialogContentProps,
+    type ModalDialogFooterProps,
+    type ModalDialogRootProps,
+    type ModalDialogTitleProps,
+} from "./modal-dialog";
+export {
     NewsCard,
     type NewsCardAuthorProps,
     type NewsCardDateProps,
     type NewsCardPlayer,
     type NewsCardThumbnailProps,
 } from "./news-card";
+export {
+    Pagination,
+    type PaginationContextProps,
+    type PaginationEllipsisProps,
+    type PaginationItemProps,
+    type PaginationNextTriggerProps,
+    type PaginationPrevTriggerProps,
+    type PaginationRootProps,
+} from "./pagination";
 export { PlayerAvatar, type PlayerAvatarProps, type PlayerAvatarSize } from "./player-avatar";
 export { PlayerMap, type PlayerMapProps, type PlayerMapSize } from "./player-map";
 export {
@@ -32,4 +72,31 @@ export {
     type PlayerPhraseCardBodyProps,
     type PlayerPhraseCardRootProps,
 } from "./player-phrase-card";
+export { Portal, type PortalProps } from "./portal";
+export { Skeleton, type SkeletonProps, type SkeletonVariant } from "./skeleton";
 export { SkinViewer, type SkinViewerAnimation, type SkinViewerProps } from "./skin-viewer";
+export { Spinner, type SpinnerProps, type SpinnerSize } from "./spinner";
+export {
+    type CreateToasterProps,
+    type CreateToasterReturn,
+    createToaster,
+    type ToastActionTriggerProps,
+    type ToastCloseTriggerProps,
+    type ToastContentProps,
+    type ToastDescriptionProps,
+    Toaster,
+    type ToasterRootProps,
+    type ToastIndicatorProps,
+    type ToastOptions,
+    type ToastRootProps,
+    type ToastTitleProps,
+    type ToastType,
+} from "./toast";
+export {
+    Tooltip,
+    type TooltipArrowProps,
+    type TooltipContentProps,
+    type TooltipPositionerProps,
+    type TooltipRootProps,
+    type TooltipTriggerProps,
+} from "./tooltip";

--- a/packages/react/src/components/menu/index.tsx
+++ b/packages/react/src/components/menu/index.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { Menu as ArkMenu } from "@ark-ui/react/menu";
+import type { ComponentProps } from "react";
+import { cx } from "styled-system/css";
+import { menu } from "styled-system/recipes";
+
+// item 以外のスロットは variant に依存しないため一度だけ解決すれば済む
+const styles = menu();
+
+// 通常項目(colorPalette 追従)か、削除/ログアウトなど危険な操作向けの danger か
+type MenuItemVariant = "default" | "danger";
+
+type MenuRootProps = ComponentProps<typeof ArkMenu.Root>;
+
+// メニュー全体の状態(開閉・選択)を管理する Provider。自身は DOM を描画しない
+const MenuRoot = (props: MenuRootProps) => {
+    return <ArkMenu.Root {...props} />;
+};
+
+type MenuTriggerProps = ComponentProps<typeof ArkMenu.Trigger>;
+
+// メニューを開くトリガー。asChild で任意の要素(IconButton など)に差し替えられる
+const MenuTrigger = ({ className, ...props }: MenuTriggerProps) => {
+    return <ArkMenu.Trigger {...props} className={cx(styles.trigger, className)} />;
+};
+
+type MenuPositionerProps = ComponentProps<typeof ArkMenu.Positioner>;
+
+// Content の位置決めを行う要素。Portal でくるんで使うことを想定
+const MenuPositioner = ({ className, ...props }: MenuPositionerProps) => {
+    return <ArkMenu.Positioner {...props} className={cx(styles.positioner, className)} />;
+};
+
+type MenuContentProps = ComponentProps<typeof ArkMenu.Content>;
+
+// ポップオーバー風のカード。項目一覧を内包する
+const MenuContent = ({ className, ...props }: MenuContentProps) => {
+    return <ArkMenu.Content {...props} className={cx(styles.content, className)} />;
+};
+
+type MenuItemProps = ComponentProps<typeof ArkMenu.Item> & {
+    /** 見た目のバリエーション。default(通常) / danger(削除・ログアウトなど破壊的な操作) */
+    variant?: MenuItemVariant;
+};
+
+// 1 項目。ホバー/キーボード操作時は data-highlighted に応じたハイライトが付く
+const MenuItem = ({ className, variant = "default", ...props }: MenuItemProps) => {
+    // variant によって色が変わるため item だけ variant 込みで解決する
+    const itemClass = menu({ variant }).item;
+    return <ArkMenu.Item {...props} className={cx(itemClass, className)} />;
+};
+
+type MenuSeparatorProps = ComponentProps<typeof ArkMenu.Separator>;
+
+// 項目同士を区切る横線
+const MenuSeparator = ({ className, ...props }: MenuSeparatorProps) => {
+    return <ArkMenu.Separator {...props} className={cx(styles.separator, className)} />;
+};
+
+type MenuItemGroupProps = ComponentProps<typeof ArkMenu.ItemGroup>;
+
+// ItemGroupLabel と Item をまとめる論理的なグループ
+const MenuItemGroup = ({ className, ...props }: MenuItemGroupProps) => {
+    return <ArkMenu.ItemGroup {...props} className={cx(styles.itemGroup, className)} />;
+};
+
+type MenuItemGroupLabelProps = ComponentProps<typeof ArkMenu.ItemGroupLabel>;
+
+// ItemGroup の見出し
+const MenuItemGroupLabel = ({ className, ...props }: MenuItemGroupLabelProps) => {
+    return <ArkMenu.ItemGroupLabel {...props} className={cx(styles.itemGroupLabel, className)} />;
+};
+
+// Compound Component パターン: Menu.Root / Trigger / Positioner / Content / Item / Separator / ItemGroup / ItemGroupLabel
+const Menu = Object.assign(MenuRoot, {
+    Root: MenuRoot,
+    Trigger: MenuTrigger,
+    Positioner: MenuPositioner,
+    Content: MenuContent,
+    Item: MenuItem,
+    Separator: MenuSeparator,
+    ItemGroup: MenuItemGroup,
+    ItemGroupLabel: MenuItemGroupLabel,
+});
+
+export { Menu };
+export type {
+    MenuRootProps,
+    MenuTriggerProps,
+    MenuPositionerProps,
+    MenuContentProps,
+    MenuItemProps,
+    MenuSeparatorProps,
+    MenuItemGroupProps,
+    MenuItemGroupLabelProps,
+    MenuItemVariant,
+};

--- a/packages/react/src/components/modal-dialog/index.tsx
+++ b/packages/react/src/components/modal-dialog/index.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { ark, type HTMLArkProps } from "@ark-ui/react/factory";
+import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { cx } from "styled-system/css";
+import { modalDialog } from "styled-system/recipes";
+
+// overlay/positioner 以外のスロットは variant に依存しないため一度だけ解決すれば済む
+const styles = modalDialog();
+
+type ModalDialogRootProps = HTMLArkProps<"div"> & {
+    /** フルページ表示。暗幕とアニメーションを止め、ページの地色の上に直接置く */
+    isPage?: boolean;
+    /**
+     * 閉じるときに呼ばれる。背景クリック → 退場アニメーション完了のタイミングで発火する。
+     * 未指定のときだけ window.history.back() にフォールバックする(移植元の挙動)
+     */
+    onClose?: () => void;
+};
+
+// 暗幕 + 退場アニメーションを担う最上位。children には Container を置く
+const ModalDialogRoot = ({ className, children, isPage = false, onClose, onClick, ...props }: ModalDialogRootProps) => {
+    const [isExiting, setIsExiting] = useState(false);
+    const overlayRef = useRef<HTMLDivElement>(null);
+    // animationend のリスナーを張り直さずに最新の onClose を読むための保持
+    const onCloseRef = useRef(onClose);
+    const slots = modalDialog({ isPage, isExiting });
+
+    useEffect(() => {
+        onCloseRef.current = onClose;
+    }, [onClose]);
+
+    // モーダル表示中は背面のスクロールを止める(フルページ表示のときは不要)
+    useEffect(() => {
+        if (isPage) {
+            return;
+        }
+        const originalOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = originalOverflow;
+        };
+    }, [isPage]);
+
+    // 退場アニメーションが終わってから実際のクローズ処理を走らせる
+    useEffect(() => {
+        const overlay = overlayRef.current;
+        if (!isExiting || !overlay) {
+            return;
+        }
+        let hasClosed = false;
+
+        const handleAnimationEnd = (event: AnimationEvent) => {
+            // overlay 自身のアニメーションのみを処理し、子要素からの伝播や重複実行を防ぐ
+            if (event.target !== overlay || hasClosed) {
+                return;
+            }
+            hasClosed = true;
+            if (onCloseRef.current) {
+                onCloseRef.current();
+            } else {
+                // 移植元は履歴を1つ戻ることでモーダルを閉じていた
+                window.history.back();
+            }
+        };
+
+        overlay.addEventListener("animationend", handleAnimationEnd);
+        return () => {
+            overlay.removeEventListener("animationend", handleAnimationEnd);
+        };
+    }, [isExiting]);
+
+    const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+        onClick?.(event);
+        // 暗幕そのものを踏んだときだけ閉じる(中身のクリックでは閉じない)
+        if (!isPage && event.target === event.currentTarget) {
+            setIsExiting(true);
+        }
+    };
+
+    return (
+        <ark.div {...props} ref={overlayRef} className={cx(slots.overlay, className)} onClick={handleOverlayClick}>
+            <div className={slots.positioner}>{children}</div>
+        </ark.div>
+    );
+};
+
+type ModalDialogContainerProps = HTMLArkProps<"div"> & {
+    /** main 領域を title/footer と同じ左右余白に揃える */
+    hasMainPadding?: boolean;
+};
+
+// ダイアログ本体の枠。Title / Content / Footer を grid に配置する
+const ModalDialogContainer = ({ className, hasMainPadding = false, ...props }: ModalDialogContainerProps) => {
+    // 余白の取り方が variant で変わるため container だけ variant 込みで解決する
+    const containerClass = modalDialog({ hasMainPadding }).container;
+    return <ark.div {...props} className={cx(containerClass, className)} />;
+};
+
+type ModalDialogTitleProps = HTMLArkProps<"div">;
+
+// 見出し領域。asChild で <h2> などに差し替えられる
+const ModalDialogTitle = ({ className, ...props }: ModalDialogTitleProps) => {
+    return <ark.div {...props} className={cx(styles.title, className)} />;
+};
+
+type ModalDialogContentProps = HTMLArkProps<"div">;
+
+// 本文領域(grid の main)
+const ModalDialogContent = ({ className, ...props }: ModalDialogContentProps) => {
+    return <ark.div {...props} className={cx(styles.content, className)} />;
+};
+
+type ModalDialogFooterProps = HTMLArkProps<"div">;
+
+// 操作ボタンを並べる領域
+const ModalDialogFooter = ({ className, ...props }: ModalDialogFooterProps) => {
+    return <ark.div {...props} className={cx(styles.footer, className)} />;
+};
+
+// Compound Component パターン: ModalDialog.Root / Container / Title / Content / Footer
+const ModalDialog = Object.assign(ModalDialogRoot, {
+    Root: ModalDialogRoot,
+    Container: ModalDialogContainer,
+    Title: ModalDialogTitle,
+    Content: ModalDialogContent,
+    Footer: ModalDialogFooter,
+});
+
+export { ModalDialog };
+export type {
+    ModalDialogRootProps,
+    ModalDialogContainerProps,
+    ModalDialogTitleProps,
+    ModalDialogContentProps,
+    ModalDialogFooterProps,
+};

--- a/packages/react/src/components/pagination/index.tsx
+++ b/packages/react/src/components/pagination/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { Pagination as ArkPagination } from "@ark-ui/react/pagination";
+import type { ComponentProps } from "react";
+import { cx } from "styled-system/css";
+import { pagination } from "styled-system/recipes";
+
+// variant を持たないレシピなので、スロットのクラスは一度だけ解決すれば済む
+const styles = pagination();
+
+type PaginationRootProps = ComponentProps<typeof ArkPagination.Root>;
+
+// ページ送り全体を包む <nav>。
+// count(総件数) と pageSize からページ数を計算する。
+// ?page= のリンク遷移で使うときは type="link" と getPageUrl を渡し、
+// page を props で制御する(クライアント状態に持たない)
+const PaginationRoot = ({ className, ...props }: PaginationRootProps) => {
+    return <ArkPagination.Root {...props} className={cx(styles.root, className)} />;
+};
+
+type PaginationPrevTriggerProps = ComponentProps<typeof ArkPagination.PrevTrigger>;
+
+// 前ページへ。asChild で <a>/<Link> を差し込める。
+// 先頭ページでは zag が data-disabled を付けるので、href を外したアンカーを渡せばよい
+const PaginationPrevTrigger = ({ className, ...props }: PaginationPrevTriggerProps) => {
+    return <ArkPagination.PrevTrigger {...props} className={cx(styles.prevTrigger, className)} />;
+};
+
+type PaginationNextTriggerProps = ComponentProps<typeof ArkPagination.NextTrigger>;
+
+// 次ページへ。末尾ページで data-disabled が付く
+const PaginationNextTrigger = ({ className, ...props }: PaginationNextTriggerProps) => {
+    return <ArkPagination.NextTrigger {...props} className={cx(styles.nextTrigger, className)} />;
+};
+
+type PaginationItemProps = ComponentProps<typeof ArkPagination.Item>;
+
+// ページ番号ひとつ。type="page" と value(ページ番号)が必須。
+// 現在ページには data-selected と aria-current="page" が自動で付く
+const PaginationItem = ({ className, ...props }: PaginationItemProps) => {
+    return <ArkPagination.Item {...props} className={cx(styles.item, className)} />;
+};
+
+type PaginationEllipsisProps = ComponentProps<typeof ArkPagination.Ellipsis>;
+
+// 省略記号。children に "…" などを自分で入れる
+const PaginationEllipsis = ({ className, ...props }: PaginationEllipsisProps) => {
+    return <ArkPagination.Ellipsis {...props} className={cx(styles.ellipsis, className)} />;
+};
+
+type PaginationContextProps = ComponentProps<typeof ArkPagination.Context>;
+
+// Ark の Context をそのまま再 export する。
+// children の render prop から pages / previousPage / nextPage などの API を受け取れる
+const PaginationContext = ArkPagination.Context;
+
+// Compound Component パターン: Pagination.Root / PrevTrigger / NextTrigger / Item / Ellipsis / Context
+const Pagination = Object.assign(PaginationRoot, {
+    Root: PaginationRoot,
+    PrevTrigger: PaginationPrevTrigger,
+    NextTrigger: PaginationNextTrigger,
+    Item: PaginationItem,
+    Ellipsis: PaginationEllipsis,
+    Context: PaginationContext,
+});
+
+export { Pagination };
+export type {
+    PaginationRootProps,
+    PaginationPrevTriggerProps,
+    PaginationNextTriggerProps,
+    PaginationItemProps,
+    PaginationEllipsisProps,
+    PaginationContextProps,
+};

--- a/packages/react/src/components/portal/index.ts
+++ b/packages/react/src/components/portal/index.ts
@@ -1,0 +1,5 @@
+"use client";
+// Menu / Drawer / Tooltip などのフローティング系コンポーネントは、
+// クリッピングやスタッキングコンテキストの影響を避けるため Portal でくるんで使う。
+// 利用側に @ark-ui/react の直接依存を強いないよう、ライブラリからそのまま再エクスポートする
+export { Portal, type PortalProps } from "@ark-ui/react/portal";

--- a/packages/react/src/components/skeleton/index.tsx
+++ b/packages/react/src/components/skeleton/index.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { ark, type HTMLArkProps } from "@ark-ui/react/factory";
+import { skeleton } from "styled-system/recipes";
+
+type SkeletonVariant = "text" | "rect" | "circle";
+
+interface SkeletonProps extends HTMLArkProps<"div"> {
+    /** プレースホルダの形状。text(1行のテキスト) / rect(矩形) / circle(円形) */
+    variant?: SkeletonVariant;
+}
+
+// 読み込み中のコンテンツ位置を示す、パルス点滅するプレースホルダ
+const Skeleton = ({ className, variant, ...props }: SkeletonProps) => {
+    return <ark.div aria-hidden="true" {...props} className={skeleton({ variant }).concat(" ", className || "")} />;
+};
+
+export { Skeleton };
+export type { SkeletonProps, SkeletonVariant };

--- a/packages/react/src/components/spinner/index.tsx
+++ b/packages/react/src/components/spinner/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { ark, type HTMLArkProps } from "@ark-ui/react/factory";
+import { spinner } from "styled-system/recipes";
+
+type SpinnerSize = "sm" | "md" | "lg";
+
+interface SpinnerProps extends HTMLArkProps<"div"> {
+    /** 円の大きさ。sm(16px) / md(24px) / lg(32px) */
+    size?: SpinnerSize;
+}
+
+// 読み込み中を示す回転インジケーター。colorPalette に応じて弧の色が変わる
+const Spinner = ({ className, size, ...props }: SpinnerProps) => {
+    return (
+        <ark.div
+            role="status"
+            aria-label="読み込み中"
+            {...props}
+            className={spinner({ size }).concat(" ", className || "")}
+        />
+    );
+};
+
+export { Spinner };
+export type { SpinnerProps, SpinnerSize };

--- a/packages/react/src/components/toast/index.tsx
+++ b/packages/react/src/components/toast/index.tsx
@@ -1,0 +1,156 @@
+"use client";
+import { Portal } from "@ark-ui/react/portal";
+import {
+    Toaster as ArkToaster,
+    type CreateToasterProps,
+    type CreateToasterReturn,
+    createToaster as createArkToaster,
+    Toast,
+    type ToastOptions,
+    type ToastType,
+} from "@ark-ui/react/toast";
+import { CircleAlertIcon, CircleCheckIcon, InfoIcon, LoaderCircleIcon, TriangleAlertIcon, XIcon } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { cx } from "styled-system/css";
+import { toast as toastRecipe } from "styled-system/recipes";
+
+// toast は variant を持たず、種別の出し分けは root の data-type で行うため一度だけ解決すれば済む
+const styles = toastRecipe();
+
+// 種別ごとの既定アイコン。loading だけはレシピ側でスピナーとして回る
+const typeIcons: Record<string, ReactNode> = {
+    success: <CircleCheckIcon />,
+    error: <CircleAlertIcon />,
+    warning: <TriangleAlertIcon />,
+    info: <InfoIcon />,
+    loading: <LoaderCircleIcon />,
+};
+
+/**
+ * createToaster の薄いラッパー。
+ * placement / pauseOnPageIdle の既定値だけ与え、残りは Ark にそのまま渡す。
+ */
+const createToaster = (props: CreateToasterProps = {}): CreateToasterReturn =>
+    createArkToaster({
+        // 画面右下に積む。日本語 UI で本文を隠しにくい位置
+        placement: "bottom-end",
+        // タブが非アクティブな間はタイマーを止め、戻ってきたときに読めるようにする
+        pauseOnPageIdle: true,
+        ...props,
+    });
+
+type ToastRootProps = ComponentProps<typeof Toast.Root>;
+
+// 1 件分の toast のカード。Ark の Toast.Root に見た目を与えるだけ
+const ToastRoot = ({ className, ...props }: ToastRootProps) => {
+    return <Toast.Root {...props} className={cx(styles.root, className)} />;
+};
+
+type ToastIndicatorProps = ComponentProps<"span"> & {
+    /** 表示する種別。未指定なら info 扱い */
+    type?: ToastType;
+};
+
+// 種別アイコン。data-type を自分にも付けて、loading のときだけ回るようにする
+const ToastIndicator = ({ className, type = "info", children, ...props }: ToastIndicatorProps) => {
+    return (
+        <span {...props} aria-hidden data-type={type} className={cx(styles.indicator, className)}>
+            {children ?? typeIcons[type] ?? typeIcons.info}
+        </span>
+    );
+};
+
+type ToastContentProps = ComponentProps<"div">;
+
+// Title + Description を縦に積むテキスト領域
+const ToastContent = ({ className, ...props }: ToastContentProps) => {
+    return <div {...props} className={cx(styles.content, className)} />;
+};
+
+type ToastTitleProps = ComponentProps<typeof Toast.Title>;
+
+const ToastTitle = ({ className, ...props }: ToastTitleProps) => {
+    return <Toast.Title {...props} className={cx(styles.title, className)} />;
+};
+
+type ToastDescriptionProps = ComponentProps<typeof Toast.Description>;
+
+const ToastDescription = ({ className, ...props }: ToastDescriptionProps) => {
+    return <Toast.Description {...props} className={cx(styles.description, className)} />;
+};
+
+type ToastActionTriggerProps = ComponentProps<typeof Toast.ActionTrigger>;
+
+// 押すとアクションを実行して toast を閉じるボタン
+const ToastActionTrigger = ({ className, ...props }: ToastActionTriggerProps) => {
+    return <Toast.ActionTrigger {...props} className={cx(styles.actionTrigger, className)} />;
+};
+
+type ToastCloseTriggerProps = ComponentProps<typeof Toast.CloseTrigger>;
+
+// 右肩の × ボタン。children を渡さなければ X アイコンを描く
+const ToastCloseTrigger = ({ className, children, ...props }: ToastCloseTriggerProps) => {
+    return (
+        <Toast.CloseTrigger aria-label="閉じる" {...props} className={cx(styles.closeTrigger, className)}>
+            {children ?? <XIcon />}
+        </Toast.CloseTrigger>
+    );
+};
+
+// children を渡さなかったときに使う既定の描画。
+// indicator / title / description / action / close を toast の内容に応じて出し分ける
+const renderToast = (toast: ToastOptions) => (
+    <ToastRoot>
+        <ToastIndicator type={toast.type} />
+        <ToastContent>
+            {toast.title ? <ToastTitle>{toast.title}</ToastTitle> : null}
+            {toast.description ? <ToastDescription>{toast.description}</ToastDescription> : null}
+        </ToastContent>
+        {toast.action ? <ToastActionTrigger>{toast.action.label}</ToastActionTrigger> : null}
+        {toast.closable ? <ToastCloseTrigger /> : null}
+    </ToastRoot>
+);
+
+type ToasterRootProps = Omit<ComponentProps<typeof ArkToaster>, "children"> & {
+    /** 描画をまるごと差し替えたいときの render prop。省略すると既定のカードを描く */
+    children?: (toast: ToastOptions) => ReactNode;
+    /** false にすると Portal を使わず、その場に描画する */
+    portalled?: boolean;
+};
+
+// toast を積むリージョン。アプリのルート付近に 1 つだけ置いて使う
+const ToasterRoot = ({ children, portalled = true, ...props }: ToasterRootProps) => {
+    return (
+        <Portal disabled={!portalled}>
+            <ArkToaster {...props}>{children ?? renderToast}</ArkToaster>
+        </Portal>
+    );
+};
+
+// Compound Component パターン: Toaster.Root / Toast / Indicator / Content / Title / Description / ActionTrigger / CloseTrigger
+const Toaster = Object.assign(ToasterRoot, {
+    Root: ToasterRoot,
+    Toast: ToastRoot,
+    Indicator: ToastIndicator,
+    Content: ToastContent,
+    Title: ToastTitle,
+    Description: ToastDescription,
+    ActionTrigger: ToastActionTrigger,
+    CloseTrigger: ToastCloseTrigger,
+});
+
+export { createToaster, Toaster };
+export type {
+    CreateToasterProps,
+    CreateToasterReturn,
+    ToastOptions,
+    ToastType,
+    ToasterRootProps,
+    ToastRootProps,
+    ToastIndicatorProps,
+    ToastContentProps,
+    ToastTitleProps,
+    ToastDescriptionProps,
+    ToastActionTriggerProps,
+    ToastCloseTriggerProps,
+};

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
+import type { ComponentProps } from "react";
+import { cx } from "styled-system/css";
+import { tooltip } from "styled-system/recipes";
+
+// content/arrow 以外は variant を持たないため一度だけ解決すれば済む
+const styles = tooltip();
+
+type TooltipRootProps = ComponentProps<typeof ArkTooltip.Root>;
+
+// ツールチップ全体の開閉状態を管理する Provider。自身は DOM を描画しない。
+// openDelay/closeDelay などは ArkTooltip.Root の props としてそのまま透過する
+const TooltipRoot = (props: TooltipRootProps) => {
+    return <ArkTooltip.Root {...props} />;
+};
+
+type TooltipTriggerProps = ComponentProps<typeof ArkTooltip.Trigger>;
+
+// ツールチップを表示させる対象。見た目は持たせず素の button として描画する
+const TooltipTrigger = (props: TooltipTriggerProps) => {
+    return <ArkTooltip.Trigger {...props} />;
+};
+
+type TooltipPositionerProps = ComponentProps<typeof ArkTooltip.Positioner>;
+
+// floating-ui による位置決めを担うラッパー。Portal でくるんで使うことを想定
+const TooltipPositioner = ({ className, ...props }: TooltipPositionerProps) => {
+    return <ArkTooltip.Positioner {...props} className={cx(styles.positioner, className)} />;
+};
+
+type TooltipContentProps = ComponentProps<typeof ArkTooltip.Content>;
+
+// 実際に表示される吹き出し本体
+const TooltipContent = ({ className, ...props }: TooltipContentProps) => {
+    return <ArkTooltip.Content {...props} className={cx(styles.content, className)} />;
+};
+
+type TooltipArrowProps = ComponentProps<typeof ArkTooltip.Arrow>;
+
+// 吹き出しの先端の三角形。表示は任意
+const TooltipArrow = ({ className, ...props }: TooltipArrowProps) => {
+    return (
+        <ArkTooltip.Arrow {...props} className={cx(styles.arrow, className)}>
+            <ArkTooltip.ArrowTip />
+        </ArkTooltip.Arrow>
+    );
+};
+
+// Compound Component パターン: Tooltip.Root / Trigger / Positioner / Content / Arrow
+const Tooltip = Object.assign(TooltipRoot, {
+    Root: TooltipRoot,
+    Trigger: TooltipTrigger,
+    Positioner: TooltipPositioner,
+    Content: TooltipContent,
+    Arrow: TooltipArrow,
+});
+
+export { Tooltip };
+export type { TooltipRootProps, TooltipTriggerProps, TooltipPositionerProps, TooltipContentProps, TooltipArrowProps };

--- a/packages/react/src/preset/create-preset.ts
+++ b/packages/react/src/preset/create-preset.ts
@@ -41,12 +41,52 @@ export const createPreset = (option: PresetOptions) => {
                 semanticTokens,
                 breakpoints,
                 textStyles,
-                // 開閉系コンポーネント(Accordion など)の表示アニメーション
+                // 開閉系コンポーネント(Accordion など)の表示アニメーション。
+                // レシピ側からは animationName: "<キー名>" で参照する
                 keyframes: {
                     // 開いたときに上から滑り込みながらフェードインする
                     slideDownIn: {
                         from: { opacity: "0", transform: "translateY(-4px)" },
                         to: { opacity: "1", transform: "translateY(0)" },
+                    },
+                    // Spinner / Toast の loading インジケーターが回り続ける
+                    spin: {
+                        to: { transform: "rotate(360deg)" },
+                    },
+                    // Skeleton がゆっくり明滅してロード中を示す
+                    pulse: {
+                        "0%, 100%": { opacity: "1" },
+                        "50%": { opacity: "0.5" },
+                    },
+                    // Drawer: 背後の暗幕がフェードインする
+                    drawerFadeIn: {
+                        from: { opacity: "0" },
+                        to: { opacity: "1" },
+                    },
+                    // Drawer: パネルが画面左端から滑り込む(placement="start")
+                    drawerSlideInFromStart: {
+                        from: { transform: "translateX(-100%)" },
+                        to: { transform: "translateX(0)" },
+                    },
+                    // Drawer: パネルが画面右端から滑り込む(placement="end")
+                    drawerSlideInFromEnd: {
+                        from: { transform: "translateX(100%)" },
+                        to: { transform: "translateX(0)" },
+                    },
+                    // ModalDialog: 暗幕とダイアログの入場フェード
+                    modalDialogFadeIn: {
+                        from: { opacity: "0" },
+                        to: { opacity: "1" },
+                    },
+                    // ModalDialog: 退場フェード。この完了(animationend)がクローズ処理の合図になるため必須
+                    modalDialogFadeOut: {
+                        from: { opacity: "1" },
+                        to: { opacity: "0" },
+                    },
+                    // ModalDialog: ダイアログがわずかに拡大しながら現れる
+                    modalDialogScaleIn: {
+                        from: { transform: "scale(0.96)" },
+                        to: { transform: "scale(1)" },
                     },
                 },
                 recipes: {

--- a/packages/react/src/preset/token/recipes/badge.ts
+++ b/packages/react/src/preset/token/recipes/badge.ts
@@ -41,11 +41,11 @@ export const badge = defineRecipe({
                 bg: "colorPalette.surface",
                 color: "colorPalette.fg",
             },
-            // 枠線のみ: 背景を持たせたくない場面向け
+            // 枠線のみ: 背景を持たせたくない場面向け。Badge の既定の見た目
             outline: {
                 borderWidth: "1px",
-                // border ロールトークン(scale 7)で、solid(scale 9)ほど枠線が主張しないようにする
-                borderColor: "colorPalette.border",
+                // アルファトークン(a3 ≒ 8.7%)を使い、文字色と同系色の極薄な枠線にする
+                borderColor: "colorPalette.a3",
                 color: "colorPalette.fg",
             },
             // 淡い背景 + 枠線: subtle よりも輪郭を出しつつ outline より主張を抑えたい場面向け
@@ -74,7 +74,7 @@ export const badge = defineRecipe({
         },
     },
     defaultVariants: {
-        variant: "solid",
+        variant: "outline",
         size: "md",
     },
 });

--- a/packages/react/src/preset/token/recipes/drawer.ts
+++ b/packages/react/src/preset/token/recipes/drawer.ts
@@ -1,0 +1,135 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const drawer = defineSlotRecipe({
+    className: "drawer",
+    jsx: ["Drawer"],
+    description: "The drawer component. A dialog that slides in from a screen edge.",
+    // Ark UI Dialog の anatomy に合わせたスロット名(Root はDOMを持たないため含めない)
+    slots: ["trigger", "backdrop", "positioner", "content", "closeTrigger", "title"],
+    base: {
+        trigger: {
+            // 素の見た目は最低限のリセットのみ。asChild で差し替えて使うのが基本
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bg: "transparent",
+            border: "none",
+            borderRadius: "md",
+            color: "colorPalette.fg",
+            cursor: "pointer",
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+            _disabled: {
+                cursor: "not-allowed",
+                color: "colorPalette.fg.muted",
+            },
+        },
+        backdrop: {
+            // 画面全体を覆う半透明の暗転レイヤー
+            position: "fixed",
+            inset: "0",
+            bg: "overlay",
+            zIndex: "overlay",
+            // 開いたときにフェードインする
+            _open: {
+                animationName: "drawerFadeIn",
+                animationDuration: "normal",
+                animationTimingFunction: "easeOut",
+            },
+        },
+        positioner: {
+            // Content を画面端に配置するためだけのレイヤー。
+            // 自身はクリックを奪わず、Content の外側は下の Backdrop までクリックを通す
+            position: "fixed",
+            inset: "0",
+            zIndex: "modal",
+            display: "flex",
+            alignItems: "stretch",
+            pointerEvents: "none",
+        },
+        content: {
+            position: "relative",
+            pointerEvents: "auto",
+            display: "flex",
+            flexDirection: "column",
+            // Positioner が inset:0 + alignItems:stretch のため、Content の高さは自然にビューポート全体になる
+            height: "full",
+            maxHeight: "full",
+            width: "full",
+            maxWidth: "sm",
+            bg: "bg.panel",
+            boxShadow: "floating",
+            outline: "none",
+            overflow: "auto",
+        },
+        closeTrigger: {
+            position: "absolute",
+            insetBlockStart: "4",
+            insetInlineEnd: "4",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minWidth: "8",
+            height: "8",
+            px: "2",
+            bg: "transparent",
+            border: "none",
+            borderRadius: "full",
+            color: "colorPalette.fg.muted",
+            cursor: "pointer",
+            transitionProperty: "background",
+            transitionDuration: "fast",
+            _hover: {
+                bg: "bg.muted",
+            },
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+        },
+        title: {
+            color: "colorPalette.fg",
+            fontSize: "lg",
+            fontWeight: "semibold",
+            lineHeight: "normal",
+            px: "component.padding.xl",
+            pt: "component.padding.xl",
+        },
+    },
+    variants: {
+        // スライド方向とアンカー位置。start = 画面左、end = 画面右
+        placement: {
+            start: {
+                positioner: { justifyContent: "flex-start" },
+                content: {
+                    _open: {
+                        animationName: "drawerSlideInFromStart",
+                        animationDuration: "normal",
+                        animationTimingFunction: "easeOut",
+                    },
+                },
+            },
+            end: {
+                positioner: { justifyContent: "flex-end" },
+                content: {
+                    _open: {
+                        animationName: "drawerSlideInFromEnd",
+                        animationDuration: "normal",
+                        animationTimingFunction: "easeOut",
+                    },
+                },
+            },
+        },
+    },
+    defaultVariants: {
+        placement: "end",
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/index.ts
+++ b/packages/react/src/preset/token/recipes/index.ts
@@ -1,20 +1,30 @@
 import { accordion } from "./accordion";
 import { badge } from "./badge";
 import { button } from "./button";
+import { drawer } from "./drawer";
 import { guideCard } from "./guide-card";
 import { list } from "./list";
+import { menu } from "./menu";
 import { minecraftItem } from "./minecraft-item";
+import { modalDialog } from "./modal-dialog";
 import { newsCard } from "./news-card";
+import { pagination } from "./pagination";
 import { playerAvatar } from "./player-avatar";
 import { playerMap } from "./player-map";
 import { playerPhraseCard } from "./player-phrase-card";
+import { skeleton } from "./skeleton";
 import { skinViewer } from "./skin-viewer";
+import { spinner } from "./spinner";
+import { toast } from "./toast";
+import { tooltip } from "./tooltip";
 
 // 単一要素のレシピ
 export const recipes = {
     button,
     badge,
     skinViewer,
+    spinner,
+    skeleton,
 };
 
 // 複数スロットを持つレシピ
@@ -27,4 +37,10 @@ export const slotRecipes = {
     minecraftItem,
     guideCard,
     newsCard,
+    menu,
+    drawer,
+    modalDialog,
+    pagination,
+    toast,
+    tooltip,
 };

--- a/packages/react/src/preset/token/recipes/menu.ts
+++ b/packages/react/src/preset/token/recipes/menu.ts
@@ -30,8 +30,12 @@ export const menu = defineSlotRecipe({
             },
         },
         positioner: {
-            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ
-            zIndex: "popover",
+            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ。
+            // ただし zag は `z-index: var(--z-index)` を **インラインで** 当てるため、
+            // クラス側の zIndex は必ず負ける。変数そのものを与えて重なり順を通す
+            // zag は positioner に `--z-index: auto; z-index: var(--z-index)` を
+            // **インラインで** 当てるため、クラス側の指定は !important でないと勝てない
+            zIndex: "popover!",
         },
         content: {
             // ポップオーバー風カード: 白背景・角丸・浮き上がる影

--- a/packages/react/src/preset/token/recipes/menu.ts
+++ b/packages/react/src/preset/token/recipes/menu.ts
@@ -1,0 +1,129 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const menu = defineSlotRecipe({
+    className: "menu",
+    jsx: ["Menu", "MenuItem"],
+    description: "The menu component",
+    // zag/Ark の anatomy に合わせたスロット名
+    slots: ["trigger", "positioner", "content", "item", "itemGroup", "itemGroupLabel", "separator"],
+    base: {
+        trigger: {
+            // asChild で任意の要素(IconButton など)に差し替えられる想定の最低限のフォールバック見た目
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "component.gap.xs",
+            bg: "transparent",
+            border: "none",
+            borderRadius: "lg",
+            color: "colorPalette.fg",
+            cursor: "pointer",
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+            _disabled: {
+                cursor: "not-allowed",
+                color: "colorPalette.fg.muted",
+            },
+        },
+        positioner: {
+            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ
+            zIndex: "popover",
+        },
+        content: {
+            // ポップオーバー風カード: 白背景・角丸・浮き上がる影
+            display: "flex",
+            flexDirection: "column",
+            minWidth: "48",
+            maxHeight: "96",
+            overflowY: "auto",
+            bg: "bg.panel",
+            borderWidth: "1px",
+            borderColor: "border.subtle",
+            borderRadius: "xl",
+            boxShadow: "floating",
+            p: "1.5",
+            outline: "none",
+            // Ark が付与する data-state=open で開閉アニメーションを再生する
+            _open: {
+                animationName: "slideDownIn",
+                animationDuration: "fast",
+                animationTimingFunction: "easeOut",
+            },
+        },
+        item: {
+            display: "flex",
+            alignItems: "center",
+            gap: "component.gap.sm",
+            borderRadius: "md",
+            px: "component.padding.md",
+            py: "component.padding.sm",
+            fontSize: "sm",
+            color: "colorPalette.fg",
+            cursor: "pointer",
+            userSelect: "none",
+            outline: "none",
+            transitionDuration: "fast",
+            transitionProperty: "background, color",
+            transitionTimingFunction: "easeInOut",
+            // キーボード操作 / ポインター両方で Ark が付与する data-highlighted な行の見た目
+            _highlighted: {
+                bg: "colorPalette.surface",
+                color: "colorPalette.fg",
+            },
+            _disabled: {
+                cursor: "not-allowed",
+                color: "fg.disabled",
+                _highlighted: {
+                    bg: "transparent",
+                },
+            },
+        },
+        itemGroup: {
+            display: "flex",
+            flexDirection: "column",
+        },
+        itemGroupLabel: {
+            px: "component.padding.md",
+            pt: "component.padding.sm",
+            pb: "1",
+            fontSize: "xs",
+            fontWeight: "semibold",
+            letterSpacing: "wide",
+            textTransform: "uppercase",
+            color: "fg.muted",
+        },
+        separator: {
+            height: "1px",
+            border: "none",
+            bg: "border.subtle",
+            mx: "1",
+            my: "1.5",
+        },
+    },
+    variants: {
+        // 通常項目(colorPalette 追従)と、削除/ログアウトなど危険な操作向けの danger を用意
+        variant: {
+            default: {
+                item: {},
+            },
+            danger: {
+                item: {
+                    color: "red.fg",
+                    _highlighted: {
+                        bg: "red.surface",
+                        color: "red.fg",
+                    },
+                },
+            },
+        },
+    },
+    defaultVariants: {
+        variant: "default",
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/modal-dialog.ts
+++ b/packages/react/src/preset/token/recipes/modal-dialog.ts
@@ -1,0 +1,144 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const modalDialog = defineSlotRecipe({
+    className: "modal-dialog",
+    jsx: ["ModalDialog"],
+    description: "The modal dialog component",
+    // overlay/positioner が Root(演出とクリック領域)、container 以下が枠と中身
+    slots: ["overlay", "positioner", "container", "title", "content", "footer"],
+    base: {
+        overlay: {
+            // 画面全体を覆う暗幕。ここを直接クリックしたときだけ閉じる
+            position: "fixed",
+            top: "0",
+            left: "0",
+            width: "full",
+            height: "full",
+            // 移植元の leaf.600/50 は、モーダル背景専用の overlay セマンティックトークンに対応付ける
+            bg: "overlay",
+            zIndex: "modal",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backdropFilter: "blur(4px)",
+            // 0.25s 相当のトークンが無いため slow(300ms) に寄せる
+            animationName: "modalDialogFadeIn",
+            animationDuration: "slow",
+            animationTimingFunction: "easeInOut",
+            animationFillMode: "both",
+            willChange: "opacity",
+        },
+        positioner: {
+            // overlay の中で container を包む演出用ラッパー。
+            // 中央寄せは overlay(flex) が担当し、こちらは拡大フェードだけを持つ
+            animationName: "modalDialogFadeIn, modalDialogScaleIn",
+            animationDuration: "slow",
+            animationTimingFunction: "easeInOut",
+            animationFillMode: "both",
+            transformOrigin: "center",
+            willChange: "opacity, transform",
+        },
+        container: {
+            // ダイアログの枠。title / main / footer の 3 スロットを固定余白の grid で並べる。
+            // 左右 38px の余白列を挟み、main だけは既定で端まで伸ばす(hasMainPadding で揃えられる)
+            bg: "bg.panel",
+            display: "grid",
+            gridTemplate: `
+                ". . ." 36px
+                ". title ." auto
+                ". . ." 24px
+                "main main main" auto
+                ". . ." 16px
+                ". footer ." auto
+                ". . ." 24px
+            `,
+            gridTemplateColumns: "38px 1fr 38px",
+            width: "560px",
+            minWidth: "560px",
+            maxWidth: "560px",
+            // 4xl = 2rem = 32px。移植元の borderRadius: 32px と一致する
+            borderRadius: "4xl",
+            overflow: "hidden",
+            color: "colorPalette.fg",
+        },
+        title: {
+            gridArea: "title",
+            // 見出し行。中に heading とサブテキストを積めるよう縦積みにしておく
+            display: "flex",
+            flexDirection: "column",
+            gap: "component.gap.xs",
+            textStyle: "2xl",
+            fontWeight: "bold",
+            color: "colorPalette.fg",
+        },
+        content: {
+            gridArea: "main",
+            // grid セルの中身(長文や overflow するリスト)がセル幅を押し広げないようにする
+            minWidth: "0",
+            color: "colorPalette.fg.muted",
+        },
+        footer: {
+            gridArea: "footer",
+            // 操作ボタンは右寄せが既定
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            gap: "component.gap.lg",
+        },
+    },
+    variants: {
+        // フルページ表示。オーバーレイではなくページそのものとして描くため、
+        // 暗幕・ぼかし・アニメーションを止めてページの地色を敷く
+        isPage: {
+            true: {
+                overlay: {
+                    position: "static",
+                    width: "auto",
+                    height: "100vh",
+                    bg: "colorPalette.bg",
+                    zIndex: "auto",
+                    backdropFilter: "none",
+                    animationName: "none",
+                },
+                positioner: {
+                    animationName: "none",
+                },
+            },
+        },
+        // 退場アニメーション中。overlay の animationend で実際のクローズ処理が走る
+        isExiting: {
+            true: {
+                overlay: {
+                    animationName: "modalDialogFadeOut",
+                    animationDuration: "normal",
+                    animationTimingFunction: "easeIn",
+                    animationFillMode: "forwards",
+                },
+                positioner: {
+                    animationName: "modalDialogFadeOut",
+                    animationDuration: "normal",
+                    animationTimingFunction: "easeIn",
+                    animationFillMode: "forwards",
+                },
+            },
+        },
+        // main も title / footer と同じ左右 38px の余白に揃える
+        hasMainPadding: {
+            true: {
+                container: {
+                    gridTemplate: `
+                        ". . ." 36px
+                        ". title ." auto
+                        ". . ." 24px
+                        ". main ." auto
+                        ". . ." 16px
+                        ". footer ." auto
+                        ". . ." 24px
+                    `,
+                },
+            },
+        },
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/pagination.ts
+++ b/packages/react/src/preset/token/recipes/pagination.ts
@@ -1,0 +1,91 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+// item / prevTrigger / nextTrigger は同じ「押せる四角いボタン」の見た目を共有する。
+// asChild で <a> を差し込む使い方が前提なので、リンクの下線と文字色も打ち消しておく
+const control = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: "0",
+    // 40px の正方形を基準に、3 桁のページ番号でも潰れないよう min で確保する
+    minWidth: "10",
+    height: "10",
+    px: "component.padding.sm",
+    borderRadius: "xl",
+    // button 要素・a 要素どちらで描画されても同じ見た目になるようリセットする
+    bg: "transparent",
+    border: "none",
+    color: "colorPalette.fg.muted",
+    fontSize: "sm",
+    fontWeight: "medium",
+    textDecoration: "none",
+    userSelect: "none",
+    cursor: "pointer",
+    transitionDuration: "normal",
+    transitionProperty: "background, color",
+    transitionTimingFunction: "easeInOut",
+    // 20px = sizes.5。prev/next に差し込むアイコン用
+    "& :where(svg)": {
+        width: "5",
+        height: "5",
+    },
+    // 現在ページ(data-selected)と無効状態には hover を効かせない。
+    // _selected と :hover は詳細度が同じため、hover 側を明示的に除外しないと現在ページが塗り替わる
+    "&:not([data-selected]):not(:disabled):not([data-disabled]):hover": {
+        bg: "colorPalette.surface",
+        color: "colorPalette.fg",
+    },
+    _focusVisible: {
+        outline: "none",
+        ringWidth: "2",
+        ringColor: "colorPalette.focus.ring",
+        ringOffset: "0",
+    },
+    // 現在ページ。zag が data-selected と aria-current="page" を付ける
+    _selected: {
+        bg: "colorPalette.solid",
+        color: "colorPalette.contrast",
+    },
+    // type="link" のとき zag は disabled 属性ではなく data-disabled だけを付ける。
+    // _disabled は :disabled / [data-disabled] の双方に当たる
+    _disabled: {
+        cursor: "not-allowed",
+        color: "fg.disabled",
+        pointerEvents: "none",
+    },
+};
+
+export const pagination = defineSlotRecipe({
+    className: "pagination",
+    jsx: ["Pagination"],
+    description: "The pagination component",
+    // zag/Ark の anatomy に合わせたスロット名
+    slots: ["root", "item", "prevTrigger", "nextTrigger", "ellipsis"],
+    base: {
+        root: {
+            // ページ送りを横一列に並べる。幅が足りなければ折り返して中央に寄せる
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexWrap: "wrap",
+            gap: "component.gap.xs",
+        },
+        item: control,
+        prevTrigger: control,
+        nextTrigger: control,
+        ellipsis: {
+            // 省略記号。押せないので cursor もフォーカスも持たせない
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: "0",
+            minWidth: "10",
+            height: "10",
+            color: "colorPalette.fg.muted",
+            fontSize: "sm",
+            userSelect: "none",
+        },
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/skeleton.ts
+++ b/packages/react/src/preset/token/recipes/skeleton.ts
@@ -1,0 +1,43 @@
+import { defineRecipe } from "@pandacss/dev";
+
+export const skeleton = defineRecipe({
+    className: "skeleton",
+    jsx: ["Skeleton"],
+    description: "The skeleton component",
+    // variant は実行時に動的指定されるため、全 variant の CSS を常に生成する
+    staticCss: ["*"],
+    base: {
+        display: "block",
+        bg: "bg.emphasized",
+        // pulse keyframes は create-preset.ts の theme.extend.keyframes に定義してある
+        animationName: "pulse",
+        animationDuration: "2s",
+        animationTimingFunction: "cubic-bezier(0.4, 0, 0.6, 1)",
+        animationIterationCount: "infinite",
+    },
+    variants: {
+        variant: {
+            // テキスト1行分のプレースホルダ
+            text: {
+                width: "full",
+                height: "4",
+                borderRadius: "sm",
+            },
+            // カード画像やバナーなどの矩形プレースホルダ。大きさは呼び出し側で指定する
+            rect: {
+                width: "full",
+                height: "full",
+                borderRadius: "lg",
+            },
+            // アバターなどの円形プレースホルダ
+            circle: {
+                width: "10",
+                height: "10",
+                borderRadius: "full",
+            },
+        },
+    },
+    defaultVariants: {
+        variant: "text",
+    },
+});

--- a/packages/react/src/preset/token/recipes/spinner.ts
+++ b/packages/react/src/preset/token/recipes/spinner.ts
@@ -1,0 +1,33 @@
+import { defineRecipe } from "@pandacss/dev";
+
+export const spinner = defineRecipe({
+    className: "spinner",
+    jsx: ["Spinner"],
+    description: "The spinner component",
+    // size は実行時に動的指定されるため、全 variant の CSS を常に生成する
+    staticCss: ["*"],
+    base: {
+        display: "inline-block",
+        flexShrink: "0",
+        borderRadius: "full",
+        borderStyle: "solid",
+        // 円のベースは薄いグレー。上辺だけ colorPalette で塗り、回転する弧に見せる
+        borderColor: "border.subtle",
+        borderTopColor: "colorPalette.solid",
+        // spin keyframes は create-preset.ts の theme.extend.keyframes に定義してある
+        animationName: "spin",
+        animationDuration: "600ms",
+        animationTimingFunction: "linear",
+        animationIterationCount: "infinite",
+    },
+    variants: {
+        size: {
+            sm: { width: "4", height: "4", borderWidth: "1" },
+            md: { width: "6", height: "6", borderWidth: "2" },
+            lg: { width: "8", height: "8", borderWidth: "4" },
+        },
+    },
+    defaultVariants: {
+        size: "md",
+    },
+});

--- a/packages/react/src/preset/token/recipes/toast.ts
+++ b/packages/react/src/preset/token/recipes/toast.ts
@@ -1,0 +1,173 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const toast = defineSlotRecipe({
+    className: "toast",
+    jsx: ["Toaster", "Toast"],
+    description: "The toast component",
+    // zag/Ark の anatomy(root/title/description/actionTrigger/closeTrigger)に、
+    // 種別アイコンの indicator と本文をまとめる content を足したスロット構成
+    slots: ["root", "indicator", "content", "title", "description", "actionTrigger", "closeTrigger"],
+    base: {
+        root: {
+            // 位置(position/absolute, top/bottom)と CSS 変数は zag が inline style で配るため、
+            // ここでは見た目とモーションだけを定義する
+            display: "flex",
+            alignItems: "start",
+            gap: "component.gap.md",
+            // 通知として読みやすい固定幅。狭い画面では viewport からはみ出さないよう縮める
+            width: "sm",
+            maxWidth: "[calc(100vw - 2rem)]",
+            p: "component.padding.lg",
+            borderRadius: "2xl",
+            borderWidth: "1px",
+            borderColor: "border.subtle",
+            bg: "bg.panel",
+            color: "fg",
+            // ページ内容の上に浮かせるため、overlay 相当の影を落とす
+            boxShadow: "overlay",
+            // 種別ごとの色は data-type で colorPalette を差し替え、
+            // CSS 変数の継承で indicator / title など子スロットへ伝える
+            colorPalette: "gray",
+            '&[data-type="success"]': { colorPalette: "mori" },
+            '&[data-type="error"]': { colorPalette: "red" },
+            '&[data-type="warning"]': { colorPalette: "yellow" },
+            '&[data-type="info"]': { colorPalette: "blue" },
+            '&[data-type="loading"]': { colorPalette: "gray" },
+            // ↓ zag が inline style で供給する CSS 変数を消費して、出入り/積み上げのモーションを作る
+            // --x/--y: 表示位置のオフセット、--scale: 背面に重なった toast の縮小率
+            translate: "[var(--x) var(--y)]",
+            scale: "[var(--scale, 1)]",
+            opacity: "[var(--opacity)]",
+            zIndex: "[var(--z-index)]",
+            // stacked/overlap のときだけ供給される。未設定なら height:auto に落ちる
+            height: "[var(--height)]",
+            willChange: "[translate, opacity, scale, height]",
+            transitionProperty: "[translate, scale, opacity, height]",
+            transitionDuration: "slower",
+            transitionTimingFunction: "emphasizedDecelerate",
+            // 消えるときは素早く引く
+            _closed: {
+                transitionDuration: "normal",
+                transitionTimingFunction: "emphasizedAccelerate",
+            },
+            // root は tabIndex=0 でフォーカスできる(hotkey で移動してくる)
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+        },
+        indicator: {
+            // 種別を表すアイコン。1 行目の文字と目線が揃うよう少しだけ下げる
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: "0",
+            marginTop: "0.5",
+            color: "colorPalette.solid",
+            // 20px = sizes.5
+            "& :where(svg)": {
+                width: "5",
+                height: "5",
+            },
+            // loading のときだけアイコンをスピナーとして回す。
+            // spin keyframes は create-preset.ts の theme.extend.keyframes に定義してある
+            '&[data-type="loading"]': {
+                animationName: "spin",
+                animationDuration: "1s",
+                animationTimingFunction: "linear",
+                animationIterationCount: "infinite",
+            },
+        },
+        content: {
+            // タイトルと説明文を縦に積む領域。余白を全部もらって伸びる
+            display: "flex",
+            flexDirection: "column",
+            gap: "component.gap.xs",
+            flex: "1",
+            // 長い文字列が縮まずに root を押し広げるのを防ぐ
+            minWidth: "0",
+        },
+        title: {
+            color: "colorPalette.fg",
+            fontSize: "sm",
+            fontWeight: "semibold",
+            lineHeight: "snug",
+        },
+        description: {
+            color: "fg.muted",
+            fontSize: "sm",
+            lineHeight: "relaxed",
+            // URL のような区切りのない文字列でも折り返す
+            overflowWrap: "anywhere",
+        },
+        actionTrigger: {
+            // 「元に戻す」などの任意アクション。テキストボタンとして控えめに置く
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: "0",
+            alignSelf: "center",
+            px: "component.padding.md",
+            py: "component.padding.xs",
+            borderRadius: "lg",
+            bg: "transparent",
+            border: "none",
+            color: "colorPalette.fg",
+            fontSize: "sm",
+            fontWeight: "semibold",
+            whiteSpace: "nowrap",
+            cursor: "pointer",
+            transitionProperty: "[background-color, color]",
+            transitionDuration: "fast",
+            transitionTimingFunction: "easeInOut",
+            _hover: {
+                bg: "colorPalette.surface",
+            },
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+        },
+        closeTrigger: {
+            // 右上の × ボタン。本文より一段控えめな色にして視線を奪わない
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: "0",
+            marginTop: "0.5",
+            // 24px = sizes.6
+            width: "6",
+            height: "6",
+            p: "0",
+            borderRadius: "full",
+            bg: "transparent",
+            border: "none",
+            color: "fg.muted",
+            cursor: "pointer",
+            transitionProperty: "[background-color, color]",
+            transitionDuration: "fast",
+            transitionTimingFunction: "easeInOut",
+            // 16px = sizes.4
+            "& :where(svg)": {
+                width: "4",
+                height: "4",
+            },
+            _hover: {
+                bg: "bg.muted",
+                color: "fg",
+            },
+            _focusVisible: {
+                outline: "none",
+                ringWidth: "2",
+                ringColor: "colorPalette.focus.ring",
+                ringOffset: "0",
+            },
+        },
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/tooltip.ts
+++ b/packages/react/src/preset/token/recipes/tooltip.ts
@@ -1,0 +1,48 @@
+import { defineSlotRecipe } from "@pandacss/dev";
+
+export const tooltip = defineSlotRecipe({
+    className: "tooltip",
+    jsx: ["Tooltip"],
+    description: "The tooltip component",
+    // Root/Trigger は見た目を持たない構造要素なのでスロットに含めない
+    slots: ["positioner", "content", "arrow"],
+    base: {
+        positioner: {
+            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ
+            zIndex: "tooltip",
+        },
+        content: {
+            // 吹き出し本体: 背景を反転させ、どのページ地の上でも読める濃色パネルにする
+            display: "inline-flex",
+            alignItems: "center",
+            maxWidth: "64",
+            borderRadius: "md",
+            bg: "bg.inverted",
+            color: "white",
+            fontSize: "xs",
+            fontWeight: "medium",
+            lineHeight: "normal",
+            px: "component.padding.md",
+            py: "component.padding.sm",
+            boxShadow: "lg",
+            outline: "none",
+            wordBreak: "break-word",
+            // トリガーの hover 判定を邪魔しないよう、吹き出し自体はクリックを透過する
+            pointerEvents: "none",
+            // Ark が付与する data-state=open で開閉アニメーションを再生する
+            _open: {
+                animationName: "slideDownIn",
+                animationDuration: "fast",
+                animationTimingFunction: "easeOut",
+            },
+        },
+        arrow: {
+            // 三角形の描画自体は zag のインラインスタイルが担う。
+            // ここでは大きさと色を CSS 変数として渡すだけでよい
+            "--arrow-size": "token(sizes.2)",
+            "--arrow-background": "token(colors.bg.inverted)",
+        },
+    },
+    // 利用者側で動的に使われても CSS が出るよう全 variant を生成する
+    staticCss: ["*"],
+});

--- a/packages/react/src/preset/token/recipes/tooltip.ts
+++ b/packages/react/src/preset/token/recipes/tooltip.ts
@@ -8,8 +8,12 @@ export const tooltip = defineSlotRecipe({
     slots: ["positioner", "content", "arrow"],
     base: {
         positioner: {
-            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ
-            zIndex: "tooltip",
+            // 実際の位置決めは zag のインラインスタイルが担う。重なり順だけここで持つ。
+            // zag はインラインで `z-index: var(--z-index)` を当てるので、
+            // クラス側の zIndex ではなく変数を定義する必要がある
+            // zag は positioner に `--z-index: auto; z-index: var(--z-index)` を
+            // **インラインで** 当てるため、クラス側の指定は !important でないと勝てない
+            zIndex: "tooltip!",
         },
         content: {
             // 吹き出し本体: 背景を反転させ、どのページ地の上でも読める濃色パネルにする

--- a/storybook/stories/badge/index.stories.tsx
+++ b/storybook/stories/badge/index.stories.tsx
@@ -34,6 +34,13 @@ const meta: Meta<typeof Badge> = {
 export default meta;
 type Story = StoryObj<typeof Badge>;
 
+// 何も指定しない既定の見た目（variant="outline"）
+export const Default: Story = {
+    args: {
+        children: "Primary",
+    },
+};
+
 export const Solid: Story = {
     args: {
         variant: "solid",
@@ -160,7 +167,7 @@ export const Showcase: Story = {
             </div>
 
             <div className={showcaseStyles.section}>
-                <span className={showcaseStyles.label}>Outline</span>
+                <span className={showcaseStyles.label}>Outline (既定)</span>
                 <div className={showcaseStyles.row}>
                     <Badge variant="outline" size="sm">
                         Small

--- a/storybook/stories/drawer/index.stories.tsx
+++ b/storybook/stories/drawer/index.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Drawer } from "../../../packages/react/src/components/drawer";
+import { Portal } from "../../../packages/react/src/components/portal";
+
+const meta: Meta<typeof Drawer> = {
+    title: "OVERLAY/Drawer",
+    component: Drawer,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+// 既定(end): 画面右からスライドインする
+export const Default: Story = {
+    render: () => (
+        <Drawer.Root>
+            <Drawer.Trigger>メニューを開く</Drawer.Trigger>
+            <Portal>
+                <Drawer.Backdrop />
+                <Drawer.Positioner>
+                    <Drawer.Content>
+                        <Drawer.Title>メニュー</Drawer.Title>
+                        <div style={{ padding: "0 24px 24px" }}>
+                            <p>森の街のなかを歩き回れるのだ。</p>
+                        </div>
+                        <Drawer.CloseTrigger />
+                    </Drawer.Content>
+                </Drawer.Positioner>
+            </Portal>
+        </Drawer.Root>
+    ),
+};
+
+// start: 画面左からスライドインする(モバイルのサイドバーなどで使う想定)
+export const Start: Story = {
+    render: () => (
+        <Drawer.Root placement="start">
+            <Drawer.Trigger>サイドバーを開く</Drawer.Trigger>
+            <Portal>
+                <Drawer.Backdrop />
+                <Drawer.Positioner>
+                    <Drawer.Content>
+                        <Drawer.Title>サイドバー</Drawer.Title>
+                        <div style={{ padding: "0 24px 24px" }}>
+                            <p>左から滑り込んでくるのだ。</p>
+                        </div>
+                        <Drawer.CloseTrigger />
+                    </Drawer.Content>
+                </Drawer.Positioner>
+            </Portal>
+        </Drawer.Root>
+    ),
+};
+
+// CloseTrigger の children を差し替えたカスタムボタンの例
+export const CustomCloseButton: Story = {
+    render: () => (
+        <Drawer.Root>
+            <Drawer.Trigger>メニューを開く</Drawer.Trigger>
+            <Portal>
+                <Drawer.Backdrop />
+                <Drawer.Positioner>
+                    <Drawer.Content>
+                        <Drawer.Title>メニュー</Drawer.Title>
+                        <div style={{ padding: "0 24px 24px" }}>
+                            <p>閉じるボタンの中身を差し替えられるのだ。</p>
+                        </div>
+                        <Drawer.CloseTrigger>とじる</Drawer.CloseTrigger>
+                    </Drawer.Content>
+                </Drawer.Positioner>
+            </Portal>
+        </Drawer.Root>
+    ),
+};

--- a/storybook/stories/menu/index.stories.tsx
+++ b/storybook/stories/menu/index.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Ellipsis, LogOut, Settings, User } from "lucide-react";
+import { Menu } from "../../../packages/react/src/components/menu";
+import { Portal } from "../../../packages/react/src/components/portal";
+
+const meta: Meta<typeof Menu> = {
+    title: "OVERLAY/Menu",
+    component: Menu,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Menu>;
+
+// トリガーは asChild で任意の要素に差し替えられる。ここでは丸いアイコンボタンにする
+const TriggerButton = () => (
+    <button
+        type="button"
+        style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "36px",
+            height: "36px",
+            borderRadius: "50%",
+            border: "none",
+            background: "transparent",
+            cursor: "pointer",
+        }}
+    >
+        <Ellipsis />
+    </button>
+);
+
+export const Default: Story = {
+    render: () => (
+        <Menu.Root>
+            <Menu.Trigger asChild>
+                <TriggerButton />
+            </Menu.Trigger>
+            <Portal>
+                <Menu.Positioner>
+                    <Menu.Content>
+                        <Menu.Item value="profile">プロフィール</Menu.Item>
+                        <Menu.Item value="settings">設定</Menu.Item>
+                        <Menu.Item value="logout">ログアウト</Menu.Item>
+                    </Menu.Content>
+                </Menu.Positioner>
+            </Portal>
+        </Menu.Root>
+    ),
+};
+
+// アイコン付きの項目
+export const WithIcons: Story = {
+    render: () => (
+        <Menu.Root>
+            <Menu.Trigger asChild>
+                <TriggerButton />
+            </Menu.Trigger>
+            <Portal>
+                <Menu.Positioner>
+                    <Menu.Content>
+                        <Menu.Item value="profile">
+                            <User />
+                            プロフィール
+                        </Menu.Item>
+                        <Menu.Item value="settings">
+                            <Settings />
+                            設定
+                        </Menu.Item>
+                    </Menu.Content>
+                </Menu.Positioner>
+            </Portal>
+        </Menu.Root>
+    ),
+};
+
+// ItemGroup / ItemGroupLabel / Separator で項目をカテゴリ分けした例。
+// ログアウトは danger variant で危険な操作であることを示す
+export const WithGroups: Story = {
+    render: () => (
+        <Menu.Root>
+            <Menu.Trigger asChild>
+                <TriggerButton />
+            </Menu.Trigger>
+            <Portal>
+                <Menu.Positioner>
+                    <Menu.Content>
+                        <Menu.ItemGroup id="account">
+                            <Menu.ItemGroupLabel>アカウント</Menu.ItemGroupLabel>
+                            <Menu.Item value="profile">
+                                <User />
+                                プロフィール
+                            </Menu.Item>
+                            <Menu.Item value="settings">
+                                <Settings />
+                                設定
+                            </Menu.Item>
+                        </Menu.ItemGroup>
+                        <Menu.Separator />
+                        <Menu.Item value="logout" variant="danger">
+                            <LogOut />
+                            ログアウト
+                        </Menu.Item>
+                    </Menu.Content>
+                </Menu.Positioner>
+            </Portal>
+        </Menu.Root>
+    ),
+};
+
+// disabled な項目を含む
+export const WithDisabled: Story = {
+    render: () => (
+        <Menu.Root>
+            <Menu.Trigger asChild>
+                <TriggerButton />
+            </Menu.Trigger>
+            <Portal>
+                <Menu.Positioner>
+                    <Menu.Content>
+                        <Menu.Item value="profile">プロフィール</Menu.Item>
+                        <Menu.Item value="settings" disabled>
+                            設定(準備中)
+                        </Menu.Item>
+                        <Menu.Item value="logout" variant="danger">
+                            ログアウト
+                        </Menu.Item>
+                    </Menu.Content>
+                </Menu.Positioner>
+            </Portal>
+        </Menu.Root>
+    ),
+};

--- a/storybook/stories/modal-dialog/index.stories.tsx
+++ b/storybook/stories/modal-dialog/index.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { css } from "styled-system/css";
+import { ModalDialog } from "../../../packages/react/src/components/modal-dialog";
+import { Button } from "../../../packages/react/src/components/styled/button";
+
+const meta: Meta<typeof ModalDialog> = {
+    title: "OVERLAY/ModalDialog",
+    component: ModalDialog,
+    parameters: {
+        // overlay は position:fixed で画面全体を覆うため、余白のない全画面で見せる
+        layout: "fullscreen",
+        // autodocs は既定でストーリーをインライン描画するため、position:fixed の overlay と
+        // body のスクロールロックがドキュメントページ自体を覆ってしまう。iframe に閉じ込める
+        docs: { story: { inline: false, iframeHeight: 640 } },
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ModalDialog>;
+
+const subtitleStyle = css({ textStyle: "sm", fontWeight: "bold", color: "colorPalette.fg.muted" });
+const listStyle = css({ display: "flex", flexDirection: "column", gap: "4" });
+// main が左右いっぱいに広がる既定レイアウト用。自前で 38px の余白と区切り線を持たせる
+const bleedListStyle = css({
+    display: "flex",
+    flexDirection: "column",
+    gap: "4",
+    maxHeight: "320px",
+    overflowY: "auto",
+    py: "8",
+    px: "[38px]",
+    borderTopWidth: "1px",
+    borderBottomWidth: "1px",
+    borderColor: "border.subtle",
+});
+const stageStyle = css({ display: "grid", placeItems: "center", height: "100vh", bg: "colorPalette.bg" });
+
+const categories = [
+    { title: "お知らせ", description: "サーバーの最新情報を届ける記事なのだ。" },
+    { title: "ガイド", description: "はじめての人向けの遊びかたをまとめるのだ。" },
+    { title: "イベント", description: "開催中のイベントの詳細を書くのだ。" },
+];
+
+// 背景クリックで閉じたあとに開き直せるデモ。
+// onClose を渡さないと既定の window.history.back() が走り、Storybook の iframe ごと
+// 前のページへ戻ってしまうため、ストーリーでは必ず onClose を指定する
+const ModalDialogDemo = ({ hasMainPadding = false }: { hasMainPadding?: boolean }) => {
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
+        <div className={stageStyle}>
+            <Button intent="primary" size="lg" onClick={() => setIsOpen(true)}>
+                モーダルを開く
+            </Button>
+            {isOpen && (
+                <ModalDialog.Root onClose={() => setIsOpen(false)}>
+                    <ModalDialog.Container hasMainPadding={hasMainPadding}>
+                        <ModalDialog.Title>
+                            <span className={subtitleStyle}>新しい記事</span>
+                            記事の種類を選ぶ
+                        </ModalDialog.Title>
+                        <ModalDialog.Content>
+                            <div className={hasMainPadding ? listStyle : bleedListStyle}>
+                                {categories.map((category) => (
+                                    <div key={category.title}>
+                                        <div className={css({ fontWeight: "bold" })}>{category.title}</div>
+                                        <div className={css({ textStyle: "sm" })}>{category.description}</div>
+                                    </div>
+                                ))}
+                            </div>
+                        </ModalDialog.Content>
+                        <ModalDialog.Footer>
+                            <Button intent="plain" onClick={() => setIsOpen(false)}>
+                                やめる
+                            </Button>
+                            <Button intent="primary" onClick={() => setIsOpen(false)}>
+                                次へ進む
+                            </Button>
+                        </ModalDialog.Footer>
+                    </ModalDialog.Container>
+                </ModalDialog.Root>
+            )}
+        </div>
+    );
+};
+
+// 既定。main は左右いっぱいに広がるので、区切り線付きのスクロール領域を置ける
+export const Default: Story = {
+    render: () => <ModalDialogDemo />,
+};
+
+// main も title/footer と同じ左右 38px の余白に揃える
+export const WithMainPadding: Story = {
+    render: () => <ModalDialogDemo hasMainPadding />,
+};
+
+// isPage: 暗幕もアニメーションも使わず、ページそのものとして見せる。
+// 背景クリックでは閉じない
+export const Page: Story = {
+    render: () => (
+        <ModalDialog.Root isPage>
+            <ModalDialog.Container hasMainPadding>
+                <ModalDialog.Title>
+                    <span className={subtitleStyle}>フルページ表示</span>
+                    記事を書く
+                </ModalDialog.Title>
+                <ModalDialog.Content>
+                    モーダルではなく1枚のページとして開くときの見た目なのだ。暗幕もアニメーションも無効になるのだ。
+                </ModalDialog.Content>
+                <ModalDialog.Footer>
+                    <Button intent="plain">やめる</Button>
+                    <Button intent="primary">保存する</Button>
+                </ModalDialog.Footer>
+            </ModalDialog.Container>
+        </ModalDialog.Root>
+    ),
+};

--- a/storybook/stories/pagination/index.stories.tsx
+++ b/storybook/stories/pagination/index.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { Pagination } from "../../../packages/react/src/components/pagination";
+
+const meta: Meta<typeof Pagination> = {
+    title: "NAVIGATION/Pagination",
+    component: Pagination,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+// 10 件 x 10 ページ = 100 件のリストを想定する
+const PAGE_SIZE = 10;
+const TOTAL_COUNT = 100;
+
+// ページ移動はクライアント状態ではなく ?page= のリンク遷移で行う。
+// Root の getPageUrl と <a href> で同じ規則を使い、生成される href を一致させる
+const pageUrl = (page: number) => `?page=${page}`;
+
+// aria-label は zag が各トリガー/アイテムに付けてくれるので、翻訳だけ渡せばよい
+const translations = {
+    rootLabel: "ページ送り",
+    prevTriggerLabel: "前のページ",
+    nextTriggerLabel: "次のページ",
+    itemLabel: ({ page }: { page: number }) => `${page} ページ目`,
+};
+
+/**
+ * 現在ページを props で受け取り、リンクだけでページ送りする例。
+ * 実際のアプリでは currentPage はサーバー側(searchParams など)から渡し、
+ * <a> の代わりに next/link や TanStack Router の <Link> を asChild で差し込む。
+ */
+const LinkPagination = ({ currentPage }: { currentPage: number }) => (
+    <Pagination.Root
+        count={TOTAL_COUNT}
+        pageSize={PAGE_SIZE}
+        page={currentPage}
+        siblingCount={1}
+        translations={translations}
+        // type="link" にすると zag が <a> に載せられない disabled 属性を付けなくなる
+        type="link"
+        getPageUrl={({ page }) => pageUrl(page)}
+    >
+        <Pagination.Context>
+            {(api) => (
+                <>
+                    <Pagination.PrevTrigger asChild>
+                        {/* 先頭ページでは遷移先が無いのでリンクではない要素に差し替える(見た目は data-disabled が担当) */}
+                        {api.previousPage ? (
+                            <a href={pageUrl(api.previousPage)}>
+                                <ChevronLeftIcon />
+                            </a>
+                        ) : (
+                            <span>
+                                <ChevronLeftIcon />
+                            </span>
+                        )}
+                    </Pagination.PrevTrigger>
+                    {api.pages.map((entry, index) =>
+                        entry.type === "page" ? (
+                            <Pagination.Item key={`page-${entry.value}`} type="page" value={entry.value} asChild>
+                                {/* 現在ページには data-selected と aria-current="page" が自動で付く */}
+                                <a href={pageUrl(entry.value)}>{entry.value}</a>
+                            </Pagination.Item>
+                        ) : (
+                            // biome-ignore lint/suspicious/noArrayIndexKey: 省略記号は pages 配列の位置そのものが識別子
+                            <Pagination.Ellipsis key={`ellipsis-${index}`} index={index}>
+                                &#8230;
+                            </Pagination.Ellipsis>
+                        ),
+                    )}
+                    <Pagination.NextTrigger asChild>
+                        {api.nextPage ? (
+                            <a href={pageUrl(api.nextPage)}>
+                                <ChevronRightIcon />
+                            </a>
+                        ) : (
+                            <span>
+                                <ChevronRightIcon />
+                            </span>
+                        )}
+                    </Pagination.NextTrigger>
+                </>
+            )}
+        </Pagination.Context>
+    </Pagination.Root>
+);
+
+// 中ほどのページ。前後に省略記号が出る
+export const Default: Story = {
+    render: () => <LinkPagination currentPage={5} />,
+};
+
+// 先頭ページ。前へ戻るトリガーが data-disabled になる
+export const FirstPage: Story = {
+    render: () => <LinkPagination currentPage={1} />,
+};
+
+// 末尾ページ。次へ進むトリガーが data-disabled になる
+export const LastPage: Story = {
+    render: () => <LinkPagination currentPage={TOTAL_COUNT / PAGE_SIZE} />,
+};
+
+// 総ページ数が少なく省略記号が出ないケース。ページ番号だけを並べる最小構成
+export const FewPages: Story = {
+    render: () => (
+        <Pagination.Root
+            count={30}
+            pageSize={10}
+            page={2}
+            translations={translations}
+            type="link"
+            getPageUrl={({ page }) => pageUrl(page)}
+        >
+            <Pagination.Context>
+                {(api) =>
+                    api.pages.map((entry, index) =>
+                        entry.type === "page" ? (
+                            <Pagination.Item key={`page-${entry.value}`} type="page" value={entry.value} asChild>
+                                <a href={pageUrl(entry.value)}>{entry.value}</a>
+                            </Pagination.Item>
+                        ) : (
+                            // biome-ignore lint/suspicious/noArrayIndexKey: 省略記号は pages 配列の位置そのものが識別子
+                            <Pagination.Ellipsis key={`ellipsis-${index}`} index={index}>
+                                &#8230;
+                            </Pagination.Ellipsis>
+                        ),
+                    )
+                }
+            </Pagination.Context>
+        </Pagination.Root>
+    ),
+};

--- a/storybook/stories/skeleton/index.stories.tsx
+++ b/storybook/stories/skeleton/index.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { css } from "styled-system/css";
+import { Skeleton } from "../../../packages/react/src/components/skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+    title: "FEEDBACK/Skeleton",
+    component: Skeleton,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["text", "rect", "circle"],
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+    args: {
+        variant: "text",
+    },
+    render: (args) => <Skeleton {...args} className={css({ width: "64" })} />,
+};
+
+// text/rect/circle を並べた一覧
+export const Variants: Story = {
+    render: () => (
+        <div className={css({ display: "flex", flexDirection: "column", gap: "4", width: "64" })}>
+            <Skeleton variant="text" />
+            <Skeleton variant="rect" className={css({ height: "32" })} />
+            <Skeleton variant="circle" />
+        </div>
+    ),
+};
+
+// text を複数並べて段落の読み込み中を表現する
+export const TextLines: Story = {
+    render: () => (
+        <div className={css({ display: "flex", flexDirection: "column", gap: "2", width: "64" })}>
+            <Skeleton variant="text" />
+            <Skeleton variant="text" />
+            <Skeleton variant="text" className={css({ width: "3/4" })} />
+        </div>
+    ),
+};
+
+// GuideCard/NewsCard のようなカードの読み込み中を想定した組み合わせ例
+export const CardPlaceholder: Story = {
+    render: () => (
+        <div
+            className={css({
+                display: "flex",
+                gap: "4",
+                p: "4",
+                width: "80",
+                bg: "bg.panel",
+                borderRadius: "2xl",
+                boxShadow: "sm",
+            })}
+        >
+            <Skeleton variant="rect" className={css({ width: "16", height: "16", flexShrink: "0" })} />
+            <div className={css({ display: "flex", flexDirection: "column", gap: "2", flex: "1" })}>
+                <Skeleton variant="text" className={css({ width: "3/4", height: "5" })} />
+                <Skeleton variant="text" />
+                <Skeleton variant="text" className={css({ width: "1/2" })} />
+            </div>
+        </div>
+    ),
+};

--- a/storybook/stories/spinner/index.stories.tsx
+++ b/storybook/stories/spinner/index.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { css } from "styled-system/css";
+import { Spinner } from "../../../packages/react/src/components/spinner";
+
+const meta: Meta<typeof Spinner> = {
+    title: "FEEDBACK/Spinner",
+    component: Spinner,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["sm", "md", "lg"],
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+export const Default: Story = {
+    args: {
+        size: "md",
+    },
+};
+
+const rowStyle = css({ display: "flex", gap: "4", alignItems: "center" });
+
+// sm/md/lg を並べたサイズ一覧
+export const Sizes: Story = {
+    render: () => (
+        <div className={rowStyle}>
+            <Spinner size="sm" />
+            <Spinner size="md" />
+            <Spinner size="lg" />
+        </div>
+    ),
+};
+
+// 弧の色は colorPalette トークンに追従する。
+// colorPalette は JSX の prop ではなく css() で生成したクラスとして渡す
+export const ColorPalette: Story = {
+    render: () => (
+        <div className={rowStyle}>
+            <Spinner className={css({ colorPalette: "mori" })} />
+            <Spinner className={css({ colorPalette: "umi" })} />
+            <Spinner className={css({ colorPalette: "red" })} />
+        </div>
+    ),
+};

--- a/storybook/stories/toast/index.stories.tsx
+++ b/storybook/stories/toast/index.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../../../packages/react/src/components/button";
+import { createToaster, Toaster } from "../../../packages/react/src/components/toast";
+
+const meta: Meta<typeof Toaster> = {
+    title: "FEEDBACK/Toast",
+    component: Toaster,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toaster>;
+
+// 実アプリでは createToaster はモジュールスコープで 1 回だけ呼び、
+// アプリ全体で同じ store を使い回す。
+// ここでは autodocs で全ストーリーが同時にマウントされても
+// 同じ toast が重複して描かれないよう、ストーリーごとに store を分けている
+const toaster = createToaster();
+const closableToaster = createToaster();
+const actionToaster = createToaster();
+const promiseToaster = createToaster();
+
+// 画面上部に出したい場合の例。placement は createToaster に渡して切り替える
+const topToaster = createToaster({ placement: "top" });
+
+const row = { display: "flex", gap: 8, flexWrap: "wrap" as const };
+
+// 種別ごとの見た目。data-type に応じて colorPalette が切り替わる
+export const Default: Story = {
+    render: () => (
+        <>
+            <div style={row}>
+                <Button
+                    size="sm"
+                    onClick={() => toaster.success({ title: "保存したのだ", description: "変更を反映したのだ。" })}
+                >
+                    success
+                </Button>
+                <Button
+                    size="sm"
+                    onClick={() =>
+                        toaster.error({ title: "保存に失敗したのだ", description: "時間を置いて試すのだ。" })
+                    }
+                >
+                    error
+                </Button>
+                <Button size="sm" onClick={() => toaster.info({ title: "新しいお知らせがあるのだ" })}>
+                    info
+                </Button>
+                <Button size="sm" onClick={() => toaster.warning({ title: "残りの枠が少ないのだ" })}>
+                    warning
+                </Button>
+                <Button
+                    size="sm"
+                    onClick={() => toaster.loading({ title: "送信しているのだ", description: "少し待つのだ。" })}
+                >
+                    loading
+                </Button>
+            </div>
+            <Toaster toaster={toaster} />
+        </>
+    ),
+};
+
+// closable: true を渡した toast だけ × ボタンが出る
+export const Closable: Story = {
+    render: () => (
+        <>
+            <div style={row}>
+                <Button
+                    size="sm"
+                    onClick={() =>
+                        closableToaster.success({
+                            title: "ずんだもちを送ったのだ",
+                            description: "相手の口座に届くまで少しかかるのだ。",
+                            closable: true,
+                        })
+                    }
+                >
+                    閉じられる toast
+                </Button>
+            </div>
+            <Toaster toaster={closableToaster} />
+        </>
+    ),
+};
+
+// action を渡すと本文の右にテキストボタンが出る。押すと onClick 実行後に閉じる
+export const WithAction: Story = {
+    render: () => (
+        <>
+            <div style={row}>
+                <Button
+                    size="sm"
+                    onClick={() =>
+                        actionToaster.create({
+                            title: "1 件削除したのだ",
+                            action: {
+                                label: "元に戻す",
+                                onClick: () => actionToaster.success({ title: "元に戻したのだ" }),
+                            },
+                        })
+                    }
+                >
+                    action 付き toast
+                </Button>
+            </div>
+            <Toaster toaster={actionToaster} />
+        </>
+    ),
+};
+
+// promise の解決/失敗に合わせて loading → success/error と中身が差し替わる
+export const PromiseToast: Story = {
+    name: "Promise",
+    render: () => (
+        <>
+            <div style={row}>
+                <Button
+                    size="sm"
+                    onClick={() =>
+                        promiseToaster.promise(new Promise((resolve) => setTimeout(resolve, 2000)), {
+                            loading: { title: "送信中なのだ" },
+                            success: { title: "送信できたのだ" },
+                            error: { title: "送信に失敗したのだ" },
+                        })
+                    }
+                >
+                    promise toast
+                </Button>
+            </div>
+            <Toaster toaster={promiseToaster} />
+        </>
+    ),
+};
+
+// placement を top にした toaster の例
+export const TopPlacement: Story = {
+    render: () => (
+        <>
+            <div style={row}>
+                <Button size="sm" onClick={() => topToaster.info({ title: "画面上部に出るのだ" })}>
+                    上に出す
+                </Button>
+            </div>
+            <Toaster toaster={topToaster} />
+        </>
+    ),
+};

--- a/storybook/stories/tooltip/index.stories.tsx
+++ b/storybook/stories/tooltip/index.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { css } from "styled-system/css";
+import { Portal } from "../../../packages/react/src/components/portal";
+import { Tooltip } from "../../../packages/react/src/components/tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+    title: "OVERLAY/Tooltip",
+    component: Tooltip,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+const triggerStyle = css({
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "10",
+    px: "4",
+    borderRadius: "lg",
+    border: "none",
+    bg: "colorPalette.solid",
+    color: "colorPalette.contrast",
+    fontSize: "sm",
+    fontWeight: "medium",
+    cursor: "pointer",
+});
+
+export const Default: Story = {
+    render: () => (
+        <Tooltip.Root>
+            <Tooltip.Trigger className={triggerStyle}>ホバーしてね</Tooltip.Trigger>
+            <Portal>
+                <Tooltip.Positioner>
+                    <Tooltip.Content>合言葉を送るのだ</Tooltip.Content>
+                </Tooltip.Positioner>
+            </Portal>
+        </Tooltip.Root>
+    ),
+};
+
+// 吹き出しの先端に三角形を付けたバージョン
+export const WithArrow: Story = {
+    render: () => (
+        <Tooltip.Root>
+            <Tooltip.Trigger className={triggerStyle}>ホバーしてね</Tooltip.Trigger>
+            <Portal>
+                <Tooltip.Positioner>
+                    <Tooltip.Content>
+                        <Tooltip.Arrow />
+                        合言葉を送るのだ
+                    </Tooltip.Content>
+                </Tooltip.Positioner>
+            </Portal>
+        </Tooltip.Root>
+    ),
+};
+
+// placement を変えて表示位置を切り替える
+export const Placements: Story = {
+    render: () => (
+        <div className={css({ display: "flex", gap: "8" })}>
+            {(["top", "right", "bottom", "left"] as const).map((placement) => (
+                <Tooltip.Root key={placement} positioning={{ placement }}>
+                    <Tooltip.Trigger className={triggerStyle}>{placement}</Tooltip.Trigger>
+                    <Portal>
+                        <Tooltip.Positioner>
+                            <Tooltip.Content>
+                                <Tooltip.Arrow />
+                                {placement} に表示するのだ
+                            </Tooltip.Content>
+                        </Tooltip.Positioner>
+                    </Portal>
+                </Tooltip.Root>
+            ))}
+        </div>
+    ),
+};
+
+// openDelay/closeDelay は ArkTooltip.Root の props としてそのまま渡せる
+export const CustomDelay: Story = {
+    render: () => (
+        <Tooltip.Root openDelay={0} closeDelay={500}>
+            <Tooltip.Trigger className={triggerStyle}>すぐ出て、ゆっくり消える</Tooltip.Trigger>
+            <Portal>
+                <Tooltip.Positioner>
+                    <Tooltip.Content>
+                        <Tooltip.Arrow />
+                        openDelay=0 / closeDelay=500
+                    </Tooltip.Content>
+                </Tooltip.Positioner>
+            </Portal>
+        </Tooltip.Root>
+    ),
+};
+
+// disabled にすると常に表示されない
+export const Disabled: Story = {
+    render: () => (
+        <Tooltip.Root disabled>
+            <Tooltip.Trigger className={triggerStyle}>disabled なのだ</Tooltip.Trigger>
+            <Portal>
+                <Tooltip.Positioner>
+                    <Tooltip.Content>
+                        <Tooltip.Arrow />
+                        表示されないはずなのだ
+                    </Tooltip.Content>
+                </Tooltip.Positioner>
+            </Portal>
+        </Tooltip.Root>
+    ),
+};


### PR DESCRIPTION
## Summary

Adds the components wiki-frontend needs to drop Chakra UI, following the existing conventions (slot recipes with `staticCss: ["*"]`, Ark UI wrappers, compound components, Storybook stories):

- `Menu` (Ark Menu; destructive item variant)
- `Drawer` (Ark Dialog based, `placement: start/end`)
- `ModalDialog` (ported from wiki-frontend's ModalDialogContainer/Wrapper; `onClose` prop with `history.back()` fallback, `isPage` variant)
- `Pagination` (Ark Pagination, link-driven via `asChild`)
- `Toaster` / `createToaster` (Ark Toast)
- `Tooltip`, `Spinner`, `Skeleton`
- `Portal` re-export (so consumers don't need a direct `@ark-ui/react` dependency)

Keyframes (`spin`, `pulse`, drawer/modal animations) are centralized in `create-preset.ts`.

## Verification

- `panda codegen` green across packages/react, storybook and docs; all new recipes emit CSS (`mpc-*` rules confirmed via cssgen)
- `tsc --noEmit` green in packages/react; no new errors in storybook/docs
- `pnpm run check` (biome) clean

## Feedback from the first consumer (wiki-frontend)

- Consider adding `"sideEffects": false` to packages/react/package.json — without it, importing the barrel pulls SkinViewer → three.js (~488KB) into consumer bundles; wiki-frontend currently works around this with a webpack rule
- `@ark-ui/react` 5.38+ imports React 19.2's `Activity`, which breaks consumers on Next 15's bundled React; wiki-frontend pins 5.37.0 via pnpm override