### PR TITLE
🎨 Darken colorPalette.bg.default & fix Menu story trigger

### DIFF
--- a/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
@@ -76,8 +76,10 @@ export const blue = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.blue.2}",
+                value: "color-mix(in oklch, {colors.blue.2}, {colors.blue.3} 50%)",
             },
             subtle: {
                 value: "{colors.blue.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
@@ -76,8 +76,10 @@ export const gray = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.gray.2}",
+                value: "color-mix(in oklch, {colors.gray.2}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.gray.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
@@ -75,8 +75,10 @@ export const mori = defineSemanticTokens.colors({
             value: "{colors.mori.light.a12}",
         },
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.mori.2}",
+                value: "color-mix(in oklch, {colors.mori.2}, {colors.mori.3} 50%)",
             },
             subtle: {
                 value: "{colors.mori.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/red.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/red.ts
@@ -76,8 +76,10 @@ export const red = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.red.2}",
+                value: "color-mix(in oklch, {colors.red.2}, {colors.red.3} 50%)",
             },
             subtle: {
                 value: "{colors.red.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
@@ -76,8 +76,10 @@ export const umi = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.umi.2}",
+                value: "color-mix(in oklch, {colors.umi.2}, {colors.umi.3} 50%)",
             },
             subtle: {
                 value: "{colors.umi.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
@@ -76,8 +76,10 @@ export const yellow = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
+            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
             DEFAULT: {
-                value: "{colors.yellow.2}",
+                value: "color-mix(in oklch, {colors.yellow.2}, {colors.yellow.3} 50%)",
             },
             subtle: {
                 value: "{colors.yellow.1}",

--- a/storybook/stories/menu/index.stories.tsx
+++ b/storybook/stories/menu/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Ellipsis, LogOut, Settings, User } from "lucide-react";
+import type { ComponentProps } from "react";
 import { Menu } from "../../../packages/react/src/components/menu";
 import { Portal } from "../../../packages/react/src/components/portal";
 
@@ -15,10 +16,14 @@ const meta: Meta<typeof Menu> = {
 export default meta;
 type Story = StoryObj<typeof Menu>;
 
-// トリガーは asChild で任意の要素に差し替えられる。ここでは丸いアイコンボタンにする
-const TriggerButton = () => (
+// トリガーは asChild で任意の要素に差し替えられる。ここでは丸いアイコンボタンにする。
+// asChild は cloneElement で props(onClick / aria-* / ref / className)を子へ渡すため、
+// 差し替え先のコンポーネントは受け取った props を必ず DOM 要素へ透過させる必要がある。
+// 透過し忘れるとクリックハンドラが届かず、メニューが開かなくなる
+const TriggerButton = (props: ComponentProps<"button">) => (
     <button
         type="button"
+        {...props}
         style={{
             display: "inline-flex",
             alignItems: "center",


### PR DESCRIPTION
## Summary

Two small visual fixes reported from Storybook.

### 🎨 Darken `colorPalette.bg.default`

The page ground color was `step 2` (mori: `L 98.2%`), which is close enough to white that white panels (`bg.panel` — used by `Menu.Content`, `ModalDialog`, `Tooltip`, ...) barely separated from it.

`bg.DEFAULT` now sits halfway between `step 2` and `step 3`:

```ts
value: "color-mix(in oklch, {colors.mori.2}, {colors.mori.3} 50%)"
```

`step 3` itself is taken by `surface.DEFAULT`, so a straight bump to `3` would have made cards (`GuideCard`, `NewsCard`, `Badge`, ...) blend into the ground. The mix keeps the ladder intact:

| token | before | after |
| --- | --- | --- |
| `bg.subtle` (1) | `L 99.5%` | unchanged |
| `bg.DEFAULT` (2) | `L 98.2%` | **`L 97.1%`** |
| `surface` (3) | `L 96.0%` | unchanged |

Applied to all six palettes (`gray` / `mori` / `umi` / `red` / `yellow` / `blue`) so the ground brightness stays consistent whichever palette `colorPalette` resolves to.

### 🐛 Fix the Menu story trigger not opening the menu

Clicking the `⋯` trigger in `OVERLAY/Menu` did nothing.

Ark UI implements `asChild` with `cloneElement`, handing every prop to the child element:

```js
// @ark-ui/react/dist/components/factory.js:30
return cloneElement(onlyChild, {
  ...mergeProps(restProps, onlyChild.props),
  ref: ref ? composeRefs(ref, childRef) : childRef
});
```

The story's `TriggerButton` took no props at all, so `onClick`, `ref` and the recipe's `className` were all dropped before reaching the DOM `<button>` — no listener was ever attached.

`TriggerButton` now accepts `ComponentProps<"button">` and spreads it onto the element. This also restores the `menu.trigger` recipe styles, which were being discarded the same way.

This is unrelated to ab49c15 / #70's z-index fix, which addressed a different problem.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm exec tsc --noEmit` in `storybook/` (only the pre-existing `apca-w3` type error remains)
- [x] `pnpm run prepare` — verified the new `color-mix` value lands in `styled-system/tokens/index.mjs`
- [ ] Visual check in Storybook (not run — no dev server was available in the session)
