### PR TITLE
🎨 Match colorPalette.bg.default to #e8f2ef by desaturating step 3 with gray

### DIFF
--- a/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/blue.ts
@@ -76,10 +76,12 @@ export const blue = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step3 の明度まで沈めつつ、
+            // gray.3 を半分混ぜて彩度を落とす。step3 と明度は同じでも彩度差が残るため、
+            // 同じ step3 を使う surface とは分離したまま沈められる。
+            // 補間空間は oklab 固定: oklch だと色相が gray の 277.7 に向かって回り青く濁る
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.blue.2}, {colors.blue.3} 50%)",
+                value: "color-mix(in oklab, {colors.blue.3}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.blue.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/gray.ts
@@ -76,10 +76,11 @@ export const gray = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // 有彩色パレットの bg は step3 に gray.3 を混ぜ、彩度差で surface と分離させたまま沈めている。
+            // gray にはその彩度の余地が無く(step2 と step3 の ΔE2000 が元々 1.87 しかない)、
+            // 沈めると surface と見分けが付かなくなるため、このパレットだけ step2 のまま据え置く
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.gray.2}, {colors.gray.3} 50%)",
+                value: "{colors.gray.2}",
             },
             subtle: {
                 value: "{colors.gray.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/mori.ts
@@ -75,10 +75,12 @@ export const mori = defineSemanticTokens.colors({
             value: "{colors.mori.light.a12}",
         },
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step3 の明度まで沈めつつ、
+            // gray.3 を半分混ぜて彩度を落とす。step3 と明度は同じでも彩度差が残るため、
+            // 同じ step3 を使う surface とは分離したまま沈められる。
+            // 補間空間は oklab 固定: oklch だと色相が gray の 277.7 に向かって回り青く濁る
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.mori.2}, {colors.mori.3} 50%)",
+                value: "color-mix(in oklab, {colors.mori.3}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.mori.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/red.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/red.ts
@@ -76,10 +76,12 @@ export const red = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step3 の明度まで沈めつつ、
+            // gray.3 を半分混ぜて彩度を落とす。step3 と明度は同じでも彩度差が残るため、
+            // 同じ step3 を使う surface とは分離したまま沈められる。
+            // 補間空間は oklab 固定: oklch だと色相が gray の 277.7 に向かって回り青く濁る
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.red.2}, {colors.red.3} 50%)",
+                value: "color-mix(in oklab, {colors.red.3}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.red.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/umi.ts
@@ -76,10 +76,12 @@ export const umi = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step3 の明度まで沈めつつ、
+            // gray.3 を半分混ぜて彩度を落とす。step3 と明度は同じでも彩度差が残るため、
+            // 同じ step3 を使う surface とは分離したまま沈められる。
+            // 補間空間は oklab 固定: oklch だと色相が gray の 277.7 に向かって回り青く濁る
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.umi.2}, {colors.umi.3} 50%)",
+                value: "color-mix(in oklab, {colors.umi.3}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.umi.1}",

--- a/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
+++ b/packages/react/src/preset/token/semantic-token/colors/base/yellow.ts
@@ -76,10 +76,12 @@ export const yellow = defineSemanticTokens.colors({
         },
         // Background semantic tokens
         bg: {
-            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step2 より一段沈める。
-            // step3 は surface が使うため、衝突しないよう step2 と step3 の中間に置く
+            // ページの地色。白いパネル(bg.panel)が浮いて見えるよう step3 の明度まで沈めつつ、
+            // gray.3 を半分混ぜて彩度を落とす。step3 と明度は同じでも彩度差が残るため、
+            // 同じ step3 を使う surface とは分離したまま沈められる。
+            // 補間空間は oklab 固定: oklch だと色相が gray の 277.7 に向かって回り青く濁る
             DEFAULT: {
-                value: "color-mix(in oklch, {colors.yellow.2}, {colors.yellow.3} 50%)",
+                value: "color-mix(in oklab, {colors.yellow.3}, {colors.gray.3} 50%)",
             },
             subtle: {
                 value: "{colors.yellow.1}",


### PR DESCRIPTION
Follow-up to #72. The ground color was asked to land on `#e8f2ef` for the `mori` palette; #72's value (`mix(mori.2, mori.3, 50%)` → `#eef9f3`) was still noticeably lighter.

## Why the mori ramp alone can't reach it

`#e8f2ef` is `oklch(95.28% 0.0113 176.3)`. The mori ramp is pinned to hue `165.1` and gains chroma as it darkens, so the target — darker *and* less saturated — sits off the ramp entirely. A CIEDE2000 sweep over every mori step and every 5% blend between them bottoms out at **ΔE 1.56** and never gets closer:

| candidate | hex | ΔE2000 vs `#e8f2ef` |
| --- | --- | --- |
| `mori.2` | `#f5fbf8` | 2.52 |
| `mori.3` | `#e7f6ef` | 3.31 |
| `mix(mori.2, mori.3, 40%)` | `#eff9f4` | 1.69 |
| `mix(mori.2, mori.5, 15%)` | `#eef8f3` | **1.56** ← best mori-only |

Matching the target's `L*` exactly (`mix(mori.2, mori.4, 63.5%)`) overshoots chroma by `+3.83 C*ab` and lands at ΔE 4.09 — visibly greener than asked.

## What this does instead

Take `step 3` for its lightness and mix in `gray.3` to strip the excess chroma:

```ts
value: "color-mix(in oklab, {colors.mori.3}, {colors.gray.3} 50%)"
```

→ `#ebf3f1`, **ΔE2000 = 1.01** against `#e8f2ef`. One blend, a round 50%, both operands at the same scale step.

**`in oklab`, not `in oklch`.** OKLCH interpolates hue along the arc, and `gray` sits at hue `277.7`, so `in oklch` swings the result to hue `221.4` — a murky blue. OKLab interpolates straight through and lands at hue `178.3` against the target's `176.3`.

## Does `surface` survive?

`surface.DEFAULT` is also `step 3`, so the concern was cards blending into the ground. They don't — the blend keeps `step 3`'s lightness but drops the chroma, so the separation is now carried by chroma instead of lightness and barely moves, while the ground gets meaningfully darker under white panels:

| palette | bg before | bg after | ΔE(bg, surface) | ΔE(bg, surface.hover) | contrast vs `bg.panel` (white) |
| --- | --- | --- | --- | --- | --- |
| mori | `#f5fbf8` | `#ebf3f1` | 4.76 → 4.19 | 8.53 → 7.70 | 1.050 → **1.126** |
| umi | `#f2fbfb` | `#e7f4f6` | 6.04 → 4.40 | 10.17 → 8.34 | 1.053 → **1.127** |
| red | `#fff7f6` | `#f9eeee` | 5.43 → 4.31 | 10.13 → 8.74 | 1.057 → **1.140** |
| yellow | `#fffbdc` | `#fef2c7` | 13.99 → 10.36 | 18.01 → 14.48 | 1.042 → **1.118** |
| blue | `#f2faff` | `#e9f2fc` | 4.24 → 3.40 | 7.73 → 6.71 | 1.052 → **1.132** |

For comparison, #72's approach dropped mori's `ΔE(bg, surface)` to 2.28 — this keeps it at 4.19, close to the 4.76 it had before either change.

## `gray` is excluded

`gray` has no chroma to spend: `gray.2` and `gray.3` are only ΔE 1.87 apart to begin with, and the same blend collapses `ΔE(bg, surface)` to **0.94** — cards would stop being visible on a gray ground. `gray.bg.DEFAULT` goes back to plain `{colors.gray.2}`, which is what it was before #72. `colorPalette: "gray"` is used by `toast` (default and `loading`), though those slots read `surface`, not `bg`.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm run prepare` — verified the `color-mix(in oklab, ...)` values land in `styled-system/tokens/index.mjs` for all five chromatic palettes, and that `gray` resolves to `var(--mpc-colors-gray-2)`
- [x] CIEDE2000 figures above computed against the scale values in `reference-tokens/color/*.ts`
- [ ] Visual check in Storybook (not run — no dev server was available in the session)
