### PR TITLE
🐛 Apply body typography on document.body so portaled overlays inherit the font

### DIFF
--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -20,11 +20,16 @@ const withTheme: Decorator = (Story, context) => {
 
         // プレビュー全体の背景をテーマの colorPalette.bg トークンで塗る。
         // colorPalette のクラスを body に付与して --mpc-colors-color-palette-* を解決させる。
-        const paletteClass = css({ colorPalette: palette }).split(" ").filter(Boolean);
-        document.body.classList.add(...paletteClass);
+        //
+        // textStyle も body に載せる。Menu / Drawer / ModalDialog / Toast / Tooltip は
+        // Portal 経由で document.body 直下にマウントされ、Story を包む decorator の div の
+        // 外に出てしまう。div にだけ textStyle を付けているとこれらにフォントが継承されない。
+        // docs 側が __root.tsx で <body> に textStyle を当てているのと条件を揃える
+        const bodyClass = css({ colorPalette: palette, textStyle: "body" }).split(" ").filter(Boolean);
+        document.body.classList.add(...bodyClass);
         document.body.style.backgroundColor = "var(--mpc-colors-color-palette-bg)";
         return () => {
-            document.body.classList.remove(...paletteClass);
+            document.body.classList.remove(...bodyClass);
         };
     }, [palette]);
 


### PR DESCRIPTION
Text inside `Menu` (and the other overlays) rendered in the browser's fallback font instead of Satoshi / GenJyuuGothic.

## Cause

Ark's `Portal` mounts into `document.body`:

```js
// @ark-ui/react/dist/components/portal/portal.js
const getPortalNode = (cb) => {
  const node = cb?.();
  const rootNode = node.getRootNode();
  if (isShadowRoot(rootNode)) return rootNode;
  return getDocument(node).body;   // ← direct child of <body>
};
```

The Storybook preview applied `textStyle: "body"` to a `<div>` wrapping `<Story />`, which lives inside `#storybook-root`. Portaled content is a sibling of that root, so it inherited nothing from it — and `font-family` only ever comes from `textStyles.body`; no recipe sets it:

```
$ panda cssgen && grep -A20 '\.menu__content' out.css | grep -i font
(no matches)
```

Affects every portaled component: `Menu`, `Drawer`, `ModalDialog`, `Toast`, `Tooltip`.

This is a Storybook-preview-only bug — `docs` already applies `textStyle: "body"` to `<body>` itself in `app/routes/__root.tsx`, so portaled overlays inherit correctly there.

## Fix

Move `textStyle` onto `document.body` in the `withTheme` decorator, alongside the `colorPalette` class it was already setting there — matching what `docs` does.

```js
> css({ colorPalette: 'mori', textStyle: 'body' })
'mpc-color-palette_mori mpc-textStyle_body'
```

and `.mpc-textStyle_body` is what carries the stack:

```css
.mpc-textStyle_body {
  font-family: var(--mpc-fonts-sans);
  ...
}
```

The wrapper `<div>` keeps its own `textStyle`; it's now redundant but harmless, and leaving it avoids touching how stories are scoped.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm exec tsc --noEmit` in `storybook/` (only the pre-existing `apca-w3` type error remains)
- [x] `panda cssgen` — confirmed `.mpc-textStyle_body` is emitted with `font-family: var(--mpc-fonts-sans)`, and that `.menu__content` carries no font of its own
- [ ] Visual check in Storybook (not run — no dev server was available in the session)
