### PR TITLE
🐛 Set the font stack on html in the preset so portaled overlays inherit it

### DIFF
--- a/packages/react/src/preset/create-preset.ts
+++ b/packages/react/src/preset/create-preset.ts
@@ -31,6 +31,15 @@ export const createPreset = (option: PresetOptions) => {
         presets: ["@pandacss/preset-base"],
         globalFontface: globalFontFace,
         globalCss: {
+            // フォントスタックは html に直接当てて文書全体へ行き渡らせる。
+            // textStyles.body 経由だと、それを適用した要素の子孫にしか効かない。
+            // Menu / Drawer / ModalDialog / Toast / Tooltip は Portal で document.body 直下に
+            // マウントされるため、アプリ側がラッパー要素に textStyle を当てている場合は
+            // その外に出てしまい、フォントだけブラウザ既定にフォールバックする。
+            // preset を導入した時点で保証されるよう、ライブラリ側で持つ
+            html: {
+                fontFamily: "sans",
+            },
             "::selection": {
                 backgroundColor: "colorPalette.5",
             },


### PR DESCRIPTION
Follow-up to #74. That PR fixed the Storybook preview, but the same bug hits any app consuming the package — which is the case that actually matters.

## The library never guaranteed the font

`fontFamily` is only ever set by `textStyles.body`:

- no recipe sets `fontFamily` (`grep -rn "fontFamily" src/preset/token/recipes/` → no matches)
- the preset's `globalCss` only carried `::selection`
- `installation.mdx` says nothing about applying `textStyle: "body"` anywhere

So the font reached elements purely by inheritance from whatever element the consuming app happened to put `textStyle: "body"` on. `docs` puts it on `<body>` and `storybook` (after #74) on `document.body`, so both looked fine — but that was each app solving it independently, not the library providing it.

Any consumer that applies `textStyle: "body"` to a wrapper element instead loses the font on every portaled overlay, since Ark mounts those into `document.body`:

```js
// @ark-ui/react/dist/components/portal/portal.js
return getDocument(node).body;
```

Affects `Menu`, `Drawer`, `ModalDialog`, `Toast`, `Tooltip`.

## Fix

Put the stack on `html` in the preset's `globalCss`, so importing the preset is enough:

```ts
globalCss: {
    html: {
        fontFamily: "sans",
    },
    "::selection": { ... },
},
```

`fontFamily` only — `textStyles.body` also carries `color`, `fontWeight` and `lineHeight`, but those are the app's call to make, and forcing them globally from a component library would be overreach.

## Layer ordering

Panda's preflight already sets a fallback on the same element:

```css
@layer reset {
  html { font-family: var(--global-font-body, var(--font-fallback)); }
}
```

The new rule lands in `@layer base`, and the cascade is declared `@layer reset, base, tokens, recipes, utilities` — so `base` wins over `reset`. Verified in both workspaces' `panda cssgen` output:

```css
@layer base{
  html {
    font-family: var(--mpc-fonts-sans);
  }
```

`docs` additionally loads Tailwind's preflight, but its `<body>` carries `.mpc-textStyle_body` from the `utilities` layer, which outranks any `html` element rule — so docs is unaffected either way.

## Test plan

- [x] `pnpm run check`
- [x] `pnpm run prepare` (all three workspaces)
- [x] `panda cssgen` in `storybook/` and `docs/` — confirmed `html { font-family: var(--mpc-fonts-sans) }` is emitted into `@layer base` in both
- [ ] Visual check against a consuming app (not run — no dev server was available in the session)
